### PR TITLE
[Hotfix] Wire calendar, fix recordings, Pacifico font, hue slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tollab — طُلّاب</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet" />
     <meta
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
         script-src  'self';
-        style-src   'self' 'unsafe-inline';
+        style-src   'self' 'unsafe-inline' https://fonts.googleapis.com;
         img-src     'self' data: https://*.googleapis.com https://*.firebaseapp.com;
-        font-src    'self';
+        font-src    'self' https://fonts.gstatic.com;
         connect-src 'self'
                     https://*.googleapis.com
                     https://*.firebaseio.com

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,9 @@ import {
   MainLayout,
   SemesterControls,
 } from '@/components/layout';
+import { WeeklySchedule } from '@/components/calendar';
 import { CourseList } from '@/components/courses';
+import { HomeworkSidebar } from '@/components/homework';
 import { AddSemesterModal, SyncConflictModal } from '@/components/modals';
 import { ToastContainer, ToastProvider } from '@/components/toast';
 import { useFirebaseSync } from '@/hooks';
@@ -93,8 +95,10 @@ function AppContent() {
             <HeaderTicker />
             <SemesterControls />
             <CourseList />
+            <WeeklySchedule />
           </>
         }
+        sidebarSlot={<HomeworkSidebar />}
       />
       <Footer />
       <AddSemesterModal />

--- a/src/components/calendar/WeeklySchedule.tsx
+++ b/src/components/calendar/WeeklySchedule.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { MOBILE_BREAKPOINT } from '@/constants/ui';
 import { useAppStore } from '@/store/app-store';
 import { useCurrentSemester } from '@/store/selectors';
-import { DEFAULT_CALENDAR_SETTINGS } from '@/types';
+import { DEFAULT_CALENDAR_SETTINGS } from '@/constants';
 
 import { CurrentTimeLine, useTimeLineCell } from './CurrentTimeLine';
 import { EventChip } from './EventChip';

--- a/src/components/courses/CourseCard.tsx
+++ b/src/components/courses/CourseCard.tsx
@@ -54,14 +54,12 @@ export const CourseCard = memo(function CourseCard({ course, index, totalCourses
   const semester = useCurrentSemester();
   const reorderCourse = useAppStore((s) => s.reorderCourse);
   const openCourseModal = useUiStore((s) => s.openCourseModal);
-  const pushModal = useUiStore((s) => s.pushModal);
 
   const metaParts = buildMetaParts(course);
 
   const handleClick = useCallback(() => {
     openCourseModal(course.id);
-    pushModal('course-modal');
-  }, [course.id, openCourseModal, pushModal]);
+  }, [course.id, openCourseModal]);
 
   const handleKeyDown = useCallback(
     handleKeyActivate(handleClick),

--- a/src/components/courses/CourseList.tsx
+++ b/src/components/courses/CourseList.tsx
@@ -21,12 +21,10 @@ export function CourseList() {
   const semester = useCurrentSemester();
   const courses = useAllCourses();
   const openCourseModal = useUiStore((s) => s.openCourseModal);
-  const pushModal = useUiStore((s) => s.pushModal);
 
   const handleAddCourse = useCallback(() => {
     openCourseModal();
-    pushModal('course-modal');
-  }, [openCourseModal, pushModal]);
+  }, [openCourseModal]);
 
   // No semester selected
   if (!semester) {

--- a/src/components/modals/CourseModal.tsx
+++ b/src/components/modals/CourseModal.tsx
@@ -69,8 +69,8 @@ function defaultHue(existingCourses: { color: string }[]): number {
   // Pick a hue maximally distant from existing ones
   let bestHue = 0;
   let bestDist = -1;
-  for (let h = 0; h <= 180; h += 10) {
-    const minDist = Math.min(...used.map((u) => Math.min(Math.abs(h - u), 180 - Math.abs(h - u))));
+  for (let h = 0; h <= 360; h += 10) {
+    const minDist = Math.min(...used.map((u) => Math.min(Math.abs(h - u), 360 - Math.abs(h - u))));
     if (minDist > bestDist) {
       bestDist = minDist;
       bestHue = h;
@@ -265,7 +265,6 @@ export function CourseModal() {
       addCourse(semester.id, {
         ...courseData,
         homework: [],
-        recordings: { tabs: [] },
       });
     }
 
@@ -556,7 +555,7 @@ export function CourseModal() {
                 id="cm-color-hue"
                 type="range"
                 min="0"
-                max="180"
+                max="360"
                 value={hue}
                 className="full-spectrum"
                 onInput={(e) => setHue(parseInt(getInputValue(e), 10))}

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -16,6 +16,7 @@ import type {
   AppSettings,
   CalendarSettings,
   Course,
+  CourseRecordings,
   Homework,
   HomeworkSortOrder,
   RecordingItem,
@@ -62,7 +63,7 @@ interface AppActions {
   renameSemester: (id: string, name: string) => void;
 
   // -- Course CRUD ----------------------------------------------------------
-  addCourse: (semesterId: string, course: Omit<Course, 'id'>) => string;
+  addCourse: (semesterId: string, course: Omit<Course, 'id' | 'recordings'> & { recordings?: CourseRecordings }) => string;
   updateCourse: (
     semesterId: string,
     courseId: string,


### PR DESCRIPTION
## Hotfix — 6 issues resolved

### Critical
- **#1** WeeklySchedule + HomeworkSidebar wired into App layout — calendar now visible!
- **#3** New courses get default Lectures + Tutorials tabs (was empty)

### Visual
- **#2** Pacifico Google Font loaded + CSP updated
- **#4** Color hue slider range 0-360 (was 0-180)

### Cleanup
- **#5** Import consistency (DEFAULT_CALENDAR_SETTINGS from @/constants)
- **#6** Dead pushModal calls removed

### Regression: typecheck ✅ | lint ✅ | build ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>