### PR TITLE
feat: add Exam Mode serpentine exam roadmap view

### DIFF
--- a/css/exam-mode.css
+++ b/css/exam-mode.css
@@ -1,0 +1,681 @@
+/**
+ * exam-mode.css
+ * Styles for Exam Mode: the persistent right-column view toggle and the compact
+ * serpentine "exam roadmap" that replaces the schedule + homework during exams.
+ *
+ * Theme-aware (uses CSS variables only; course/custom accent colors are the sole
+ * exception, applied inline and sanitized by cssColor()). Radius matches the app (2px).
+ */
+
+/* ============================================================================
+   RIGHT-COLUMN STRUCTURE
+   #semester-view must stay a flex column so the homework list keeps its scroll.
+   ============================================================================ */
+
+#semester-view {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+#exam-view {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* ============================================================================
+   VIEW TOGGLE (segmented Schedule | Exams + Auto reset)
+   ============================================================================ */
+
+.right-view-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.rv-pills {
+    display: inline-flex;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: 2px;
+    padding: 2px;
+}
+
+.rv-pill {
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 5px 14px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.rv-pill:hover {
+    color: var(--text-primary);
+}
+
+.rv-pill.is-active {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.rv-auto {
+    border: 1px solid var(--border-secondary);
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 9px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.rv-auto:hover {
+    color: var(--text-primary);
+    border-color: var(--text-tertiary);
+}
+
+/* ============================================================================
+   ROADMAP TOOLBAR
+   ============================================================================ */
+
+.exam-header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.exam-header-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.exam-countdown {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.exam-countdown-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-tertiary);
+}
+
+.exam-countdown-value {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.exam-countdown-when {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--accent);
+    margin-left: 4px;
+}
+
+.exam-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-end;
+}
+
+.exam-progress-text {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.exam-progress-bar {
+    width: 110px;
+    height: 5px;
+    border-radius: 3px;
+    background: var(--progress-bg);
+    overflow: hidden;
+}
+
+.exam-progress-fill {
+    display: block;
+    height: 100%;
+    background: var(--progress-fill);
+    transition: width 0.3s ease;
+}
+
+.exam-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.exam-filter {
+    display: inline-flex;
+    border: 1px solid var(--border-primary);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.exam-filter-btn {
+    border: none;
+    border-right: 1px solid var(--border-primary);
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 5px 11px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.exam-filter-btn:last-child {
+    border-right: none;
+}
+
+.exam-filter-btn:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.exam-filter-btn.is-active {
+    background: var(--accent);
+    color: var(--bg-secondary);
+}
+
+.exam-action-btn {
+    border: 1px solid var(--border-secondary);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 5px 12px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.exam-action-btn:hover {
+    background: var(--border-primary);
+}
+
+/* ============================================================================
+   SERPENTINE BOARD
+   ============================================================================ */
+
+.exam-board {
+    display: flex;
+    flex-direction: column;
+}
+
+.exam-row {
+    display: flex;
+    align-items: stretch;
+}
+
+/* ----- Node ----- */
+
+.exam-node {
+    flex: 1 1 120px;
+    min-width: 0;
+    position: relative;
+    display: flex;
+    border: 1px solid var(--border-primary);
+    border-radius: 2px;
+    background: var(--bg-secondary);
+    overflow: hidden;
+    cursor: pointer;
+    transition: box-shadow 0.2s, transform 0.2s, border-color 0.2s;
+}
+
+.exam-node:hover {
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.10);
+    transform: translateY(-1px);
+    border-color: var(--border-secondary);
+}
+
+.exam-node:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* Keep cards compact on multi-column boards; full width when single column (mobile). */
+.exam-board:not([data-cols="1"]) .exam-node,
+.exam-board:not([data-cols="1"]) .exam-spacer {
+    max-width: 150px;
+}
+
+/* Empty placeholder cell that keeps partial rows aligned to the column grid. */
+.exam-spacer {
+    flex: 1 1 120px;
+    min-width: 0;
+}
+
+.exam-node-accent {
+    flex: 0 0 4px;
+    align-self: stretch;
+    background: var(--accent);
+}
+
+.exam-node-body {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.exam-node-row1 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.exam-badge {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    padding: 2px 6px;
+    border-radius: 2px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.exam-badge-a {
+    color: var(--text-primary);
+}
+
+.exam-badge-custom {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px dashed var(--border-secondary);
+}
+
+.exam-node-next {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 2px 6px;
+    border-radius: 2px;
+    background: var(--accent);
+    color: var(--bg-secondary);
+}
+
+.exam-node-remove {
+    margin-left: auto;
+    border: none;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 16px;
+    line-height: 1;
+    width: 20px;
+    height: 20px;
+    border-radius: 2px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.exam-node:hover .exam-node-remove,
+.exam-node:focus-within .exam-node-remove {
+    opacity: 1;
+}
+
+.exam-node-remove:hover {
+    background: var(--error-bg);
+    color: var(--error-border);
+}
+
+.exam-node-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.exam-node-untitled {
+    color: var(--text-tertiary);
+    font-style: italic;
+    font-weight: 500;
+}
+
+.exam-node-date {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.exam-node-custom-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+.exam-node-mini {
+    border: 1px solid var(--border-secondary);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.exam-node-mini:hover {
+    background: var(--border-primary);
+    color: var(--text-primary);
+}
+
+.exam-node-mini-danger:hover {
+    background: var(--error-bg);
+    color: var(--error-border);
+    border-color: var(--error-border);
+}
+
+/* ----- Node states ----- */
+
+.exam-node.state-passed {
+    opacity: 0.5;
+}
+
+.exam-node.state-passed .exam-node-name {
+    font-weight: 500;
+}
+
+.exam-node.state-today {
+    border-color: var(--success-border);
+}
+
+.exam-node.is-custom {
+    border-style: dashed;
+}
+
+.exam-node.is-next {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+}
+
+/* ----- Horizontal connector ----- */
+
+.exam-connector {
+    flex: 1 1 40px;
+    min-width: 30px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-tertiary);
+}
+
+.exam-connector-line {
+    position: absolute;
+    left: -1px;
+    right: -1px;
+    top: 50%;
+    height: 2px;
+    background: var(--border-secondary);
+    transform: translateY(-50%);
+}
+
+.exam-connector-arrow {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    color: var(--text-tertiary);
+    background: var(--bg-secondary);
+    border-radius: 50%;
+    padding: 1px;
+}
+
+.exam-row-reverse .exam-connector-arrow {
+    transform: scaleX(-1);
+}
+
+.exam-gap-chip {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -150%);
+    z-index: 2;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--text-primary);
+    background: var(--bg-secondary);
+    padding: 2px 7px;
+    border-radius: 10px;
+    border: 1px solid var(--border-primary);
+    white-space: nowrap;
+}
+
+/* ----- Row-turn connector ----- */
+
+.exam-turn {
+    position: relative;
+    display: flex;
+    align-items: center;
+    height: 56px;
+    color: var(--text-tertiary);
+}
+
+.exam-turn-right {
+    justify-content: flex-end;
+}
+
+.exam-turn-left {
+    justify-content: flex-start;
+}
+
+.exam-turn-elbow {
+    position: absolute;
+    top: -2px;
+    height: 50%;
+    width: 2px;
+    background: var(--border-secondary);
+}
+
+.exam-turn-right .exam-turn-elbow {
+    right: 19px;
+}
+
+.exam-turn-left .exam-turn-elbow {
+    left: 19px;
+}
+
+.exam-turn-arrow {
+    display: inline-flex;
+    color: var(--text-tertiary);
+    background: var(--bg-secondary);
+    border-radius: 50%;
+    padding: 1px;
+    margin: 0 8px;
+    position: relative;
+    z-index: 1;
+}
+
+.exam-turn-arrow svg {
+    width: 18px;
+    height: 18px;
+}
+
+.exam-turn .exam-gap-chip {
+    position: static;
+    transform: none;
+}
+
+/* ============================================================================
+   EMPTY STATE
+   ============================================================================ */
+
+.exam-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+    padding: 44px 20px;
+    color: var(--text-tertiary);
+}
+
+.exam-empty-icon {
+    opacity: 0.6;
+}
+
+.exam-empty-text {
+    font-size: 13px;
+    max-width: 320px;
+    line-height: 1.5;
+}
+
+/* ============================================================================
+   HIDDEN TRAY
+   ============================================================================ */
+
+.exam-hidden-tray {
+    margin-top: 18px;
+    border-top: 1px solid var(--border-primary);
+    padding-top: 14px;
+}
+
+.exam-hidden-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-tertiary);
+    margin-bottom: 10px;
+}
+
+.exam-hidden-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.exam-hidden-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border: 1px dashed var(--border-secondary);
+    border-radius: 2px;
+    background: var(--bg-tertiary);
+}
+
+.exam-hidden-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.exam-hidden-meta {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    white-space: nowrap;
+}
+
+.exam-hidden-item .exam-node-mini {
+    flex: 0 0 auto;
+    margin-left: auto;
+}
+
+/* ============================================================================
+   RESPONSIVE
+   ============================================================================ */
+
+/* When the right column stacks below the left one, let the whole page scroll
+   naturally (no nested scroll container, which iOS can trap) and give the last
+   row room to clear the mobile browser chrome and the floating action button. */
+@media (max-width: 900px) {
+    #exam-view {
+        overflow: visible;
+        padding-bottom: 56px;
+    }
+}
+
+@media (max-width: 480px) {
+    .exam-node-body {
+        padding: 8px 10px;
+    }
+
+    .exam-connector {
+        flex-basis: 26px;
+    }
+
+    .exam-header-top {
+        align-items: flex-start;
+    }
+
+    .exam-progress {
+        align-items: flex-start;
+    }
+}
+
+/* Touch devices: keep the remove affordance discoverable without hover. */
+@media (hover: none) {
+    .exam-node-remove {
+        opacity: 0.6;
+    }
+}
+
+/* ============================================================================
+   MOTION
+   ============================================================================ */
+
+@media (prefers-reduced-motion: no-preference) {
+    .exam-node.is-next {
+        animation: exam-next-pulse 2.4s ease-in-out infinite;
+    }
+
+    @keyframes exam-next-pulse {
+        0%, 100% {
+            box-shadow: 0 0 0 1px var(--accent);
+        }
+        50% {
+            box-shadow: 0 0 0 3px var(--accent);
+        }
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .exam-node,
+    .exam-node:hover,
+    .exam-progress-fill,
+    .rv-pill,
+    .exam-action-btn,
+    .exam-filter-btn {
+        transition: none;
+    }
+
+    .exam-node:hover {
+        transform: none;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="css/modals.css">
     <link rel="stylesheet" href="css/toast.css">
     <link rel="stylesheet" href="css/utils.css">
+    <link rel="stylesheet" href="css/exam-mode.css">
 </head>
 <body>
     <div class="app-layout">
@@ -75,6 +76,16 @@
     </div>
 
     <div class="calendar-container">
+        <!-- Persistent right-column view toggle (Schedule | Exams, with Auto reset) -->
+        <div id="right-view-toggle" class="right-view-toggle hidden" role="group" aria-label="Switch right column view">
+            <div class="rv-pills">
+                <button type="button" class="rv-pill" data-view="semester" aria-pressed="false">Schedule</button>
+                <button type="button" class="rv-pill" data-view="exam" aria-pressed="false">Exams</button>
+            </div>
+            <button type="button" class="rv-auto hidden" data-view="auto" title="Revert to automatic">Auto</button>
+        </div>
+
+        <div id="semester-view">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; flex-wrap: wrap; gap: 10px;">
             <h2 style="margin: 0; font-size: 20px; font-weight: 300;">Weekly Schedule</h2>
             <div style="display: flex; align-items: center; gap: 10px;">
@@ -103,6 +114,10 @@
         <div id="homework-sidebar-list" class="upcoming-list">
             <!-- Homework populated by JS -->
         </div>
+        </div><!-- /#semester-view -->
+
+        <!-- Exam Mode roadmap (populated by js/exam-mode.js) -->
+        <div id="exam-view" class="hidden" role="region" aria-label="Exam roadmap"></div>
     </div>
     
     <!-- Mobile Scroll to Homework Button -->
@@ -641,6 +656,42 @@
         </div>
     </div>
 
+    <!-- Custom Exam Modal (Exam Mode) -->
+    <div id="custom-exam-modal" class="modal-overlay">
+        <div class="modal">
+            <div class="modal-header">
+                <h2 class="modal-title" id="custom-exam-modal-title">Add Custom Exam</h2>
+                <button class="close-btn" onclick="closeModal('custom-exam-modal')">&times;</button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="custom-exam-id">
+                <div class="form-group">
+                    <label for="custom-exam-name">Name</label>
+                    <input type="text" id="custom-exam-name" maxlength="100" placeholder="e.g., Statistics Final">
+                </div>
+                <div class="form-group">
+                    <label for="custom-exam-label">Label (optional)</label>
+                    <input type="text" id="custom-exam-label" maxlength="30" placeholder="e.g., Moed A, Quiz, Project">
+                </div>
+                <div class="form-group">
+                    <label for="custom-exam-date">Date</label>
+                    <input type="date" id="custom-exam-date" style="width: 100%; padding: 12px 14px; border: 1px solid var(--border-secondary); border-radius: 2px; background: var(--bg-secondary); color: var(--text-primary);">
+                </div>
+                <div class="form-group">
+                    <label for="custom-exam-hue">Color</label>
+                    <div style="display: flex; align-items: center; gap: 10px;">
+                        <input type="range" id="custom-exam-hue" min="1" max="360" value="200" style="flex: 1; cursor: pointer;">
+                        <div id="custom-exam-color-preview" style="width: 40px; height: 40px; border: 1px solid var(--border-secondary); border-radius: 4px;"></div>
+                    </div>
+                </div>
+                <div style="display: flex; gap: 10px; margin-top: 10px;">
+                    <button id="custom-exam-save-btn" class="btn-primary" style="flex: 1;">Save</button>
+                    <button id="custom-exam-delete-btn" class="btn-danger" style="display: none;">Delete</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Core modules (load order matters) -->
     <script src="js/constants.js"></script>
     <script src="js/validation.js"></script>
@@ -665,6 +716,7 @@
     <script src="js/item-logic.js"></script>
     <script src="js/import-export.js"></script>
     <script src="js/events.js"></script>
+    <script src="js/exam-mode.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/events.js
+++ b/js/events.js
@@ -20,6 +20,11 @@ function setupEventListeners() {
     setupProfileEvents();
     setupColorThemeEvents();
     setupMobileDayToggle();
+
+    // Exam Mode (manual toggle, roadmap actions, custom-exam modal)
+    if (typeof setupExamModeEvents === 'function') {
+        setupExamModeEvents();
+    }
 }
 
 // ============================================================================

--- a/js/exam-mode.js
+++ b/js/exam-mode.js
@@ -1,0 +1,1294 @@
+/**
+ * @fileoverview Exam Mode: a compact, serpentine "exam roadmap" that replaces the
+ * right column (Weekly Schedule + Homework) during the exam period.
+ *
+ * The view activates automatically when today falls inside the exam window
+ * (firstExam - EXAM_MODE_LEAD_DAYS .. lastExam, inclusive), with a subtle manual
+ * per-semester override (Schedule | Exams | Auto). Nodes are derived from each
+ * course's exams (Moed A / Moed B) plus user-defined custom exams, sorted by date.
+ *
+ * Persistence: three per-semester fields (examViewMode, hiddenExamIds, customExams)
+ * are stored on the full semester object and round-trip through the compact v2
+ * schema (see compactExamMode / hydrateExamMode, wired from state.js).
+ *
+ * Security: every user-controlled string (course/custom name, label) is escaped via
+ * escapeHtml() before innerHTML, titles are set through escaped attributes or the DOM
+ * .title property, accent colors pass through cssColor() to block CSS injection, and
+ * all node actions use event delegation with data-* attributes (no user data in inline JS).
+ */
+
+'use strict';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Days before the first exam that Exam Mode auto-activates. */
+const EXAM_MODE_LEAD_DAYS = 14;
+
+/** Manual view-mode options stored per semester. */
+const EXAM_VIEW_MODES = Object.freeze({
+    AUTO: 'auto',
+    SEMESTER: 'semester',
+    EXAM: 'exam'
+});
+
+/** Target width (px) per roadmap node, used to compute responsive columns. */
+const EXAM_NODE_TARGET_WIDTH = 150;
+
+/** Maximum number of columns in the serpentine layout. */
+const EXAM_MAX_COLUMNS = 6;
+
+/** Short month names for compact date display (local, avoids constants.js coupling). */
+const EXAM_MONTHS_SHORT = Object.freeze([
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+]);
+
+/** Short day names for compact date display. */
+const EXAM_DAY_NAMES = Object.freeze(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+
+const EXAM_CHEVRON_RIGHT = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="9 18 15 12 9 6"></polyline></svg>';
+const EXAM_CHEVRON_DOWN = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>';
+
+// ============================================================================
+// TRANSIENT (non-persisted) UI STATE
+// ============================================================================
+
+/** @type {'all'|'A'|'B'} Current Moed filter (not persisted). */
+let examMoedFilter = 'all';
+
+/** @type {ResizeObserver|null} Observer driving responsive serpentine re-layout. */
+let examResizeObserver = null;
+
+// ============================================================================
+// DATE HELPERS (pure)
+// ============================================================================
+
+/**
+ * Parses a 'YYYY-MM-DD' string into a local-midnight Date.
+ * @param {string} dateStr - Date string.
+ * @returns {Date|null} Local-midnight Date, or null if invalid.
+ */
+function parseExamDate(dateStr) {
+    if (!dateStr || typeof dateStr !== 'string') return null;
+    const m = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!m) return null;
+    const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+    d.setHours(0, 0, 0, 0);
+    if (Number.isNaN(d.getTime())) return null;
+    // Guard against rollovers (e.g. 2024-02-31).
+    if (d.getMonth() !== Number(m[2]) - 1 || d.getDate() !== Number(m[3])) return null;
+    return d;
+}
+
+/**
+ * Returns a copy of a date set to local midnight.
+ * @param {Date} date - Source date.
+ * @returns {Date} Local-midnight copy.
+ */
+function toLocalMidnight(date) {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    return d;
+}
+
+/**
+ * Whole days from a to b (b - a), using local midnight to avoid timezone drift.
+ * @param {Date} a - Start date.
+ * @param {Date} b - End date.
+ * @returns {number} Signed integer day difference.
+ */
+function daysBetween(a, b) {
+    const da = toLocalMidnight(a).getTime();
+    const db = toLocalMidnight(b).getTime();
+    return Math.round((db - da) / 86400000);
+}
+
+/**
+ * Days from today until a given exam date (negative if passed).
+ * @param {string} dateStr - 'YYYY-MM-DD'.
+ * @param {Date} [today] - Reference date (defaults to now).
+ * @returns {number|null} Day count, or null if invalid.
+ */
+function daysUntil(dateStr, today = new Date()) {
+    const d = parseExamDate(dateStr);
+    if (!d) return null;
+    return daysBetween(today, d);
+}
+
+/**
+ * Formats an exam date compactly, e.g. "Mon, 12 Jun".
+ * @param {string} dateStr - 'YYYY-MM-DD'.
+ * @returns {string} Formatted date, or '' if invalid.
+ */
+function formatExamDate(dateStr) {
+    const d = parseExamDate(dateStr);
+    if (!d) return '';
+    return `${EXAM_DAY_NAMES[d.getDay()]}, ${d.getDate()} ${EXAM_MONTHS_SHORT[d.getMonth()]}`;
+}
+
+// ============================================================================
+// EXAM COLLECTION & SORT (pure)
+// ============================================================================
+
+/**
+ * Builds the stable node id for a real course exam.
+ * @param {string} courseId - Course id.
+ * @param {'A'|'B'} moed - Exam moed.
+ * @returns {string} Node id.
+ */
+function examNodeId(courseId, moed) {
+    return `${courseId}:${moed}`;
+}
+
+/**
+ * Collects all exam nodes for a semester (course Moed A/B + custom exams),
+ * filtered to valid dates and sorted ascending by date.
+ * @param {Object} semester - Semester object.
+ * @param {{includeHidden?: boolean}} [options] - When includeHidden is true, hidden
+ *   nodes are kept (flagged via node.hidden) instead of being filtered out.
+ * @returns {Array<Object>} Sorted exam nodes.
+ */
+function collectExams(semester, options = {}) {
+    if (!semester) return [];
+    const includeHidden = options.includeHidden === true;
+    const hidden = new Set(Array.isArray(semester.hiddenExamIds) ? semester.hiddenExamIds : []);
+    const nodes = [];
+
+    (semester.courses || []).forEach(course => {
+        if (!course || !course.exams) return;
+        [['A', course.exams.moedA], ['B', course.exams.moedB]].forEach(([moed, date]) => {
+            const parsed = parseExamDate(date);
+            if (!parsed) return;
+            const id = examNodeId(course.id, moed);
+            const isHidden = hidden.has(id);
+            if (isHidden && !includeHidden) return;
+            nodes.push({
+                id,
+                courseId: course.id,
+                name: course.name || '',
+                color: course.color || '',
+                moed,
+                label: `Moed ${moed}`,
+                date,
+                dateObj: parsed,
+                custom: false,
+                hidden: isHidden
+            });
+        });
+    });
+
+    (semester.customExams || []).forEach(ex => {
+        if (!ex) return;
+        const parsed = parseExamDate(ex.date);
+        if (!parsed) return;
+        const id = ex.id;
+        const isHidden = hidden.has(id);
+        if (isHidden && !includeHidden) return;
+        nodes.push({
+            id,
+            courseId: null,
+            name: ex.name || '',
+            color: ex.color || '',
+            moed: null,
+            label: ex.label || 'Exam',
+            date: ex.date,
+            dateObj: parsed,
+            custom: true,
+            hidden: isHidden
+        });
+    });
+
+    nodes.sort((a, b) => {
+        const diff = a.dateObj - b.dateObj;
+        if (diff !== 0) return diff;
+        if (a.custom !== b.custom) return a.custom ? 1 : -1;
+        if (!a.custom && !b.custom && a.courseId === b.courseId && a.moed !== b.moed) {
+            return a.moed === 'A' ? -1 : 1;
+        }
+        return (a.name || '').localeCompare(b.name || '');
+    });
+
+    return nodes;
+}
+
+// ============================================================================
+// VIEW-MODE DECISION (pure)
+// ============================================================================
+
+/**
+ * Returns the min/max exam dates as local-midnight Dates.
+ * @param {Array<Object>} exams - Exam nodes.
+ * @returns {{first: Date, last: Date}|null} Window, or null when empty.
+ */
+function getExamWindow(exams) {
+    if (!exams || exams.length === 0) return null;
+    let first = exams[0].dateObj;
+    let last = exams[0].dateObj;
+    exams.forEach(e => {
+        if (e.dateObj < first) first = e.dateObj;
+        if (e.dateObj > last) last = e.dateObj;
+    });
+    return { first: toLocalMidnight(first), last: toLocalMidnight(last) };
+}
+
+/**
+ * Decides whether Exam Mode should auto-activate for the given exams.
+ * Active when firstExam - leadDays <= today <= lastExam (inclusive).
+ * @param {Array<Object>} exams - Exam nodes.
+ * @param {Date} [today] - Reference date.
+ * @param {number} [leadDays] - Lead window in days.
+ * @returns {boolean} Whether the date falls within the exam window.
+ */
+function isExamModeActiveByDate(exams, today = new Date(), leadDays = EXAM_MODE_LEAD_DAYS) {
+    const win = getExamWindow(exams);
+    if (!win) return false;
+    const t = toLocalMidnight(today);
+    const start = toLocalMidnight(win.first);
+    start.setDate(start.getDate() - leadDays);
+    const end = toLocalMidnight(win.last);
+    return t >= start && t <= end;
+}
+
+/**
+ * Resolves the effective view ('exam' or 'semester') for a semester, honoring a
+ * manual override and otherwise deciding automatically by date.
+ * @param {Object} semester - Semester object.
+ * @param {Date} [today] - Reference date.
+ * @param {number} [leadDays] - Lead window in days.
+ * @returns {'exam'|'semester'} Effective view mode.
+ */
+function resolveExamViewMode(semester, today = new Date(), leadDays = EXAM_MODE_LEAD_DAYS) {
+    const mode = semester && semester.examViewMode;
+    if (mode === EXAM_VIEW_MODES.EXAM) return EXAM_VIEW_MODES.EXAM;
+    if (mode === EXAM_VIEW_MODES.SEMESTER) return EXAM_VIEW_MODES.SEMESTER;
+    const exams = collectExams(semester);
+    return isExamModeActiveByDate(exams, today, leadDays) ? EXAM_VIEW_MODES.EXAM : EXAM_VIEW_MODES.SEMESTER;
+}
+
+/**
+ * Annotates nodes with a lifecycle state and marks the single "next" exam.
+ * @param {Array<Object>} nodes - Sorted exam nodes.
+ * @param {Date} [today] - Reference date.
+ * @returns {Array<Object>} New nodes with {state:'passed'|'today'|'upcoming', isNext}.
+ */
+function annotateExamStates(nodes, today = new Date()) {
+    const t = toLocalMidnight(today);
+    let nextAssigned = false;
+    return nodes.map(node => {
+        const d = node.dateObj || parseExamDate(node.date);
+        let state = 'upcoming';
+        if (d) {
+            const cmp = daysBetween(t, d);
+            if (cmp < 0) state = 'passed';
+            else if (cmp === 0) state = 'today';
+        }
+        let isNext = false;
+        if (!nextAssigned && state !== 'passed') {
+            isNext = true;
+            nextAssigned = true;
+        }
+        return Object.assign({}, node, { state, isNext });
+    });
+}
+
+/**
+ * Absolute day gap between two nodes (for study-gap connector labels).
+ * @param {Object} a - First node.
+ * @param {Object} b - Second node.
+ * @returns {number|null} Absolute days, or null when undeterminable.
+ */
+function gapDays(a, b) {
+    if (!a || !b || !a.dateObj || !b.dateObj) return null;
+    return Math.abs(daysBetween(a.dateObj, b.dateObj));
+}
+
+// ============================================================================
+// HIDE / RESTORE (non-destructive; never touches course exam data)
+// ============================================================================
+
+/**
+ * Hides a node from the roadmap by id (does not delete underlying exam data).
+ * @param {Object} semester - Semester object.
+ * @param {string} nodeId - Node id.
+ * @returns {boolean} True if the hidden set changed.
+ */
+function hideExamNode(semester, nodeId) {
+    if (!semester || !nodeId) return false;
+    if (!Array.isArray(semester.hiddenExamIds)) semester.hiddenExamIds = [];
+    if (semester.hiddenExamIds.includes(nodeId)) return false;
+    semester.hiddenExamIds.push(nodeId);
+    return true;
+}
+
+/**
+ * Restores a previously hidden node.
+ * @param {Object} semester - Semester object.
+ * @param {string} nodeId - Node id.
+ * @returns {boolean} True if the hidden set changed.
+ */
+function restoreExamNode(semester, nodeId) {
+    if (!semester || !Array.isArray(semester.hiddenExamIds)) return false;
+    const idx = semester.hiddenExamIds.indexOf(nodeId);
+    if (idx === -1) return false;
+    semester.hiddenExamIds.splice(idx, 1);
+    return true;
+}
+
+/**
+ * Clears all hidden nodes for a semester.
+ * @param {Object} semester - Semester object.
+ * @returns {boolean} True if anything was cleared.
+ */
+function clearHiddenExams(semester) {
+    if (!semester || !Array.isArray(semester.hiddenExamIds) || semester.hiddenExamIds.length === 0) {
+        return false;
+    }
+    semester.hiddenExamIds = [];
+    return true;
+}
+
+// ============================================================================
+// CUSTOM EXAMS (pure CRUD)
+// ============================================================================
+
+/**
+ * Validates and normalizes custom exam input.
+ * @param {Object} data - {name, label, date, color}.
+ * @returns {{valid: boolean, error?: string, value?: Object}} Result.
+ */
+function validateCustomExam(data) {
+    const name = data && typeof data.name === 'string' ? data.name.trim() : '';
+    const date = data && typeof data.date === 'string' ? data.date.trim() : '';
+    if (!name) return { valid: false, error: 'Exam name is required' };
+    if (name.length > 100) return { valid: false, error: 'Exam name is too long (max 100 characters)' };
+    if (!parseExamDate(date)) return { valid: false, error: 'A valid date (YYYY-MM-DD) is required' };
+    const label = data && typeof data.label === 'string' ? data.label.trim().slice(0, 30) : '';
+    const color = data && typeof data.color === 'string' ? data.color.trim() : '';
+    return { valid: true, value: { name, label, date, color } };
+}
+
+/**
+ * Adds a custom exam to a semester.
+ * @param {Object} semester - Semester object.
+ * @param {Object} data - {name, label, date, color}.
+ * @returns {Object} The created exam, or {error} on failure.
+ */
+function addCustomExam(semester, data) {
+    if (!semester) return { error: 'No semester selected' };
+    const v = validateCustomExam(data);
+    if (!v.valid) return { error: v.error };
+    if (!Array.isArray(semester.customExams)) semester.customExams = [];
+    const exam = {
+        id: generateId(),
+        name: v.value.name,
+        label: v.value.label,
+        date: v.value.date,
+        color: v.value.color
+    };
+    semester.customExams.push(exam);
+    return exam;
+}
+
+/**
+ * Updates an existing custom exam.
+ * @param {Object} semester - Semester object.
+ * @param {string} id - Custom exam id.
+ * @param {Object} patch - Partial {name, label, date, color}.
+ * @returns {Object} The updated exam, or {error} on failure.
+ */
+function updateCustomExam(semester, id, patch) {
+    if (!semester || !Array.isArray(semester.customExams)) return { error: 'No semester selected' };
+    const exam = semester.customExams.find(e => e.id === id);
+    if (!exam) return { error: 'Custom exam not found' };
+    const merged = {
+        name: patch && patch.name !== undefined ? patch.name : exam.name,
+        label: patch && patch.label !== undefined ? patch.label : exam.label,
+        date: patch && patch.date !== undefined ? patch.date : exam.date,
+        color: patch && patch.color !== undefined ? patch.color : exam.color
+    };
+    const v = validateCustomExam(merged);
+    if (!v.valid) return { error: v.error };
+    exam.name = v.value.name;
+    exam.label = v.value.label;
+    exam.date = v.value.date;
+    exam.color = v.value.color;
+    return exam;
+}
+
+/**
+ * Removes a custom exam (and any hidden-id referencing it).
+ * @param {Object} semester - Semester object.
+ * @param {string} id - Custom exam id.
+ * @returns {Object|null} The removed exam, or null if not found.
+ */
+function removeCustomExam(semester, id) {
+    if (!semester || !Array.isArray(semester.customExams)) return null;
+    const idx = semester.customExams.findIndex(e => e.id === id);
+    if (idx === -1) return null;
+    const removed = semester.customExams.splice(idx, 1)[0];
+    restoreExamNode(semester, id);
+    return removed;
+}
+
+// ============================================================================
+// COMPACT SERIALIZATION (wired into state.js compact/hydrate)
+// ============================================================================
+
+/**
+ * Compacts a semester's exam-mode fields for storage. Returns undefined when all
+ * values are default so nothing is written.
+ * @param {Object} semester - Full semester object.
+ * @returns {Object|undefined} Compact fields {vm?, hx?, cx?}.
+ */
+function compactExamMode(semester) {
+    if (!semester) return undefined;
+    const out = {};
+    if (semester.examViewMode && semester.examViewMode !== EXAM_VIEW_MODES.AUTO) {
+        out.vm = semester.examViewMode;
+    }
+    if (Array.isArray(semester.hiddenExamIds) && semester.hiddenExamIds.length > 0) {
+        out.hx = semester.hiddenExamIds.slice();
+    }
+    if (Array.isArray(semester.customExams) && semester.customExams.length > 0) {
+        out.cx = semester.customExams.map(e => {
+            const c = { i: e.id, n: e.name, d: e.date };
+            if (e.label) c.l = e.label;
+            if (e.color) c.c = e.color;
+            return c;
+        });
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Hydrates exam-mode fields from compact storage, filling defaults.
+ * @param {Object} s - Compact semester object.
+ * @returns {{examViewMode: string, hiddenExamIds: string[], customExams: Object[]}} Fields.
+ */
+function hydrateExamMode(s) {
+    const result = {
+        examViewMode: EXAM_VIEW_MODES.AUTO,
+        hiddenExamIds: [],
+        customExams: []
+    };
+    if (!s) return result;
+    if (s.vm === EXAM_VIEW_MODES.SEMESTER || s.vm === EXAM_VIEW_MODES.EXAM) {
+        result.examViewMode = s.vm;
+    }
+    if (Array.isArray(s.hx)) result.hiddenExamIds = s.hx.slice();
+    if (Array.isArray(s.cx)) {
+        result.customExams = s.cx.map(c => ({
+            id: c.i || generateId(),
+            name: c.n || '',
+            label: c.l || '',
+            date: c.d || '',
+            color: c.c || ''
+        }));
+    }
+    return result;
+}
+
+// ============================================================================
+// RENDERING
+// ============================================================================
+
+/**
+ * Sanitizes a color so it is safe to interpolate into an inline style attribute.
+ * Only hex, hsl(a), rgb(a) and bare named colors pass; anything else falls back.
+ * @param {string} color - Candidate color string.
+ * @returns {string} A safe CSS color value.
+ */
+function cssColor(color) {
+    if (typeof color !== 'string') return 'var(--accent)';
+    const c = color.trim();
+    if (/^#[0-9a-fA-F]{3,8}$/.test(c)) return c;
+    if (/^hsla?\(\s*[\d.]+\s*,\s*[\d.]+%\s*,\s*[\d.]+%\s*(?:,\s*[\d.]+\s*)?\)$/.test(c)) return c;
+    if (/^rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*(?:,\s*[\d.]+\s*)?\)$/.test(c)) return c;
+    if (/^[a-zA-Z]+$/.test(c)) return c;
+    return 'var(--accent)';
+}
+
+/**
+ * Resolves the exam-mode DOM elements (may be absent during partial loads).
+ * @returns {{semesterView: HTMLElement|null, examView: HTMLElement|null, toggle: HTMLElement|null}}
+ */
+function getExamModeElements() {
+    return {
+        semesterView: $('semester-view'),
+        examView: $('exam-view'),
+        toggle: $('right-view-toggle')
+    };
+}
+
+/**
+ * Top-level render entry, called from renderAll() on every data change. Swaps the
+ * right column between Semester view and Exam view and updates the manual toggle.
+ */
+function renderExamMode() {
+    const els = getExamModeElements();
+    if (!els.examView || !els.semesterView) return;
+
+    const semester = typeof getCurrentSemester === 'function' ? getCurrentSemester() : null;
+
+    if (!semester) {
+        showSemesterView(els);
+        updateViewToggle(els, EXAM_VIEW_MODES.SEMESTER, EXAM_VIEW_MODES.AUTO, false);
+        return;
+    }
+
+    const resolved = resolveExamViewMode(semester);
+    if (resolved === EXAM_VIEW_MODES.EXAM) {
+        showExamView(els);
+        renderExamRoadmap(semester, els.examView);
+    } else {
+        showSemesterView(els);
+    }
+    updateViewToggle(els, resolved, semester.examViewMode || EXAM_VIEW_MODES.AUTO, true);
+}
+
+/**
+ * Reveals the exam view and hides the semester view.
+ * @param {Object} els - Element bundle from getExamModeElements().
+ */
+function showExamView(els) {
+    els.semesterView.classList.add('hidden');
+    els.examView.classList.remove('hidden');
+}
+
+/**
+ * Reveals the semester view and hides the exam view, tearing down the observer.
+ * @param {Object} els - Element bundle from getExamModeElements().
+ */
+function showSemesterView(els) {
+    els.examView.classList.add('hidden');
+    els.semesterView.classList.remove('hidden');
+    teardownExamResizeObserver();
+}
+
+/**
+ * Updates the segmented pills and the Auto reset chip.
+ * @param {Object} els - Element bundle.
+ * @param {string} resolvedMode - Effective mode ('exam'|'semester').
+ * @param {string} storedMode - Stored mode ('auto'|'semester'|'exam').
+ * @param {boolean} enabled - Whether the toggle should be visible.
+ */
+function updateViewToggle(els, resolvedMode, storedMode, enabled) {
+    if (!els.toggle) return;
+    els.toggle.classList.toggle('hidden', !enabled);
+
+    const schedBtn = els.toggle.querySelector('[data-view="semester"]');
+    const examBtn = els.toggle.querySelector('[data-view="exam"]');
+    const autoBtn = els.toggle.querySelector('[data-view="auto"]');
+
+    if (schedBtn) {
+        const on = resolvedMode === EXAM_VIEW_MODES.SEMESTER;
+        schedBtn.classList.toggle('is-active', on);
+        schedBtn.setAttribute('aria-pressed', String(on));
+    }
+    if (examBtn) {
+        const on = resolvedMode === EXAM_VIEW_MODES.EXAM;
+        examBtn.classList.toggle('is-active', on);
+        examBtn.setAttribute('aria-pressed', String(on));
+    }
+    if (autoBtn) {
+        const overridden = storedMode === EXAM_VIEW_MODES.SEMESTER || storedMode === EXAM_VIEW_MODES.EXAM;
+        autoBtn.classList.toggle('hidden', !overridden);
+    }
+}
+
+/**
+ * Renders the full roadmap (toolbar + serpentine board + optional hidden tray).
+ * @param {Object} semester - Semester object.
+ * @param {HTMLElement} container - The #exam-view container.
+ */
+function renderExamRoadmap(semester, container) {
+    teardownExamResizeObserver();
+    container.innerHTML = '';
+
+    const allNodes = annotateExamStates(collectExams(semester, { includeHidden: true }));
+    const visible = allNodes.filter(n => !n.hidden);
+    const hiddenNodes = allNodes.filter(n => n.hidden);
+
+    const filtered = visible.filter(n => {
+        if (examMoedFilter === 'A') return n.moed === 'A';
+        if (examMoedFilter === 'B') return n.moed === 'B';
+        return true;
+    });
+
+    container.appendChild(buildExamHeader(filtered));
+
+    if (filtered.length === 0) {
+        container.appendChild(buildExamEmptyState(visible.length === 0));
+    } else {
+        const board = document.createElement('div');
+        board.className = 'exam-board';
+        board.setAttribute('role', 'list');
+        board.setAttribute('aria-label', 'Exam roadmap');
+        container.appendChild(board);
+        layoutExamRows(board, filtered);
+        setupExamResizeObserver(board, filtered);
+    }
+
+    if (hiddenNodes.length > 0) {
+        container.appendChild(buildHiddenTray(hiddenNodes));
+    }
+}
+
+/**
+ * Builds the roadmap toolbar: next-exam countdown, progress, Moed filter, actions.
+ * @param {Array<Object>} nodes - Visible (filtered) annotated nodes.
+ * @returns {HTMLElement} Header element.
+ */
+function buildExamHeader(nodes) {
+    const header = document.createElement('div');
+    header.className = 'exam-header';
+
+    const next = nodes.find(n => n.isNext);
+    const total = nodes.length;
+    const done = nodes.filter(n => n.state === 'passed').length;
+
+    let countdownHtml;
+    if (next) {
+        const d = daysUntil(next.date);
+        let when;
+        if (d === 0) when = 'Today';
+        else if (d === 1) when = 'Tomorrow';
+        else when = `in ${d} days`;
+        countdownHtml = `
+            <div class="exam-countdown">
+                <span class="exam-countdown-label">Next exam</span>
+                <span class="exam-countdown-value">${escapeHtml(next.name) || 'Untitled exam'} <span class="exam-countdown-when">${escapeHtml(when)}</span></span>
+            </div>`;
+    } else {
+        countdownHtml = `
+            <div class="exam-countdown exam-countdown-empty">
+                <span class="exam-countdown-label">Exam roadmap</span>
+                <span class="exam-countdown-value">All done</span>
+            </div>`;
+    }
+
+    const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+    const progressHtml = total > 0
+        ? `<div class="exam-progress" title="${done} of ${total} exams done">
+               <span class="exam-progress-text">${done} / ${total} done</span>
+               <span class="exam-progress-bar"><span class="exam-progress-fill" style="width:${pct}%"></span></span>
+           </div>`
+        : '';
+
+    const filterHtml = `
+        <div class="exam-filter" role="group" aria-label="Filter by Moed">
+            <button type="button" class="exam-filter-btn ${examMoedFilter === 'all' ? 'is-active' : ''}" data-filter="all">All</button>
+            <button type="button" class="exam-filter-btn ${examMoedFilter === 'A' ? 'is-active' : ''}" data-filter="A">A</button>
+            <button type="button" class="exam-filter-btn ${examMoedFilter === 'B' ? 'is-active' : ''}" data-filter="B">B</button>
+        </div>`;
+
+    header.innerHTML = `
+        <div class="exam-header-top">
+            ${countdownHtml}
+            ${progressHtml}
+        </div>
+        <div class="exam-actions">
+            ${filterHtml}
+            <button type="button" class="exam-action-btn" data-action="add-custom" title="Add a custom exam">+ Add</button>
+        </div>`;
+    return header;
+}
+
+/**
+ * Builds the empty-state block.
+ * @param {boolean} noneAtAll - True when there are no exams at all (vs filtered out).
+ * @returns {HTMLElement} Empty-state element.
+ */
+function buildExamEmptyState(noneAtAll) {
+    const div = document.createElement('div');
+    div.className = 'exam-empty';
+    const msg = noneAtAll
+        ? 'No exams yet. Add exam dates to your courses, or add a custom exam to start your roadmap.'
+        : 'No exams match this filter.';
+    div.innerHTML = `
+        <div class="exam-empty-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
+        </div>
+        <div class="exam-empty-text">${escapeHtml(msg)}</div>
+        <button type="button" class="exam-action-btn" data-action="add-custom">+ Add custom exam</button>`;
+    return div;
+}
+
+/**
+ * Computes the responsive column count from available width.
+ * @param {number} width - Container width in px.
+ * @param {number} count - Number of nodes.
+ * @returns {number} Column count (1..EXAM_MAX_COLUMNS).
+ */
+function computeExamColumns(width, count) {
+    const maxByCount = Math.max(1, Math.min(EXAM_MAX_COLUMNS, count || 1));
+    if (!width || width <= 0) return maxByCount;
+    const byWidth = Math.floor(width / EXAM_NODE_TARGET_WIDTH);
+    return Math.max(1, Math.min(maxByCount, byWidth));
+}
+
+/**
+ * Splits an array into chunks of a given size.
+ * @param {Array} arr - Source array.
+ * @param {number} size - Chunk size.
+ * @returns {Array<Array>} Chunked rows.
+ */
+function chunkExams(arr, size) {
+    const out = [];
+    const step = Math.max(1, size);
+    for (let i = 0; i < arr.length; i += step) out.push(arr.slice(i, i + step));
+    return out;
+}
+
+/**
+ * Builds the display-order cells for one serpentine row, padding partial rows with
+ * null spacers on the flow's trailing side (right for left-to-right rows, left for
+ * reversed rows) so real nodes stay aligned to the column grid above.
+ * @param {Array<Object>} row - Row chunk in sorted (flow) order.
+ * @param {number} cols - Column count for the board.
+ * @param {boolean} reverse - Whether the row is displayed right-to-left.
+ * @returns {Array<Object|null>} Cells in display order (a node, or null for a spacer).
+ */
+function buildRowCells(row, cols, reverse) {
+    const ordered = reverse ? row.slice().reverse() : row;
+    const pad = Math.max(0, cols - ordered.length);
+    return reverse
+        ? [...new Array(pad).fill(null), ...ordered]
+        : [...ordered, ...new Array(pad).fill(null)];
+}
+
+/**
+ * Lays out nodes as a serpentine: row 1 left-to-right, row 2 right-to-left, etc.,
+ * with horizontal connectors between nodes and a turn connector between rows.
+ * @param {HTMLElement} board - The .exam-board element.
+ * @param {Array<Object>} nodes - Sorted, annotated, filtered nodes.
+ */
+function layoutExamRows(board, nodes) {
+    const host = board.parentElement || board;
+    const width = host.clientWidth || board.clientWidth || 0;
+    const cols = computeExamColumns(width, nodes.length);
+
+    // Guard against ResizeObserver feedback loops: skip when columns are unchanged.
+    if (board.dataset.cols === String(cols) && board.childElementCount > 0) return;
+    board.dataset.cols = String(cols);
+    board.style.setProperty('--exam-cols', String(cols));
+    board.innerHTML = '';
+
+    const rows = chunkExams(nodes, cols);
+    rows.forEach((row, rowIndex) => {
+        const reverse = rowIndex % 2 === 1;
+        const cells = buildRowCells(row, cols, reverse);
+
+        const rowEl = document.createElement('div');
+        rowEl.className = `exam-row${reverse ? ' exam-row-reverse' : ''}`;
+
+        cells.forEach((cell, i) => {
+            rowEl.appendChild(cell ? buildExamNode(cell) : buildSpacer());
+            if (i < cells.length - 1) {
+                const next = cells[i + 1];
+                rowEl.appendChild(cell && next ? buildConnector(cell, next) : buildBlankConnector());
+            }
+        });
+        board.appendChild(rowEl);
+
+        if (rowIndex < rows.length - 1) {
+            // The flow crosses from the last node of this row to the first node of the
+            // next row in sorted (date) order, not display order, so the day-gap label
+            // stays correct even when a row is reversed.
+            const nextRow = rows[rowIndex + 1];
+            board.appendChild(buildTurnConnector(reverse, gapDays(row[row.length - 1], nextRow[0])));
+        }
+    });
+}
+
+/**
+ * Builds a single roadmap node. All user text is escaped; title is set via the DOM
+ * property; accent color passes through cssColor().
+ * @param {Object} node - Annotated node.
+ * @returns {HTMLElement} Node element.
+ */
+function buildExamNode(node) {
+    const el = document.createElement('div');
+    el.className = `exam-node state-${node.state}${node.isNext ? ' is-next' : ''}${node.custom ? ' is-custom' : ''}`;
+    el.setAttribute('role', 'listitem');
+    el.tabIndex = 0;
+    el.dataset.nodeId = node.id;
+    if (node.courseId) el.dataset.courseId = node.courseId;
+    if (node.moed) el.dataset.moed = node.moed;
+    el.dataset.custom = node.custom ? '1' : '0';
+    // Setting .title via the DOM property is injection-safe (no HTML parsing).
+    el.title = `${node.name || 'Untitled exam'} (${node.label}) - ${formatExamDate(node.date)}`;
+
+    const accent = cssColor(node.color);
+    const safeName = escapeHtml(node.name) || '<span class="exam-node-untitled">Untitled exam</span>';
+    const badgeClass = node.custom
+        ? 'exam-badge exam-badge-custom'
+        : (node.moed === 'A' ? 'exam-badge exam-badge-a' : 'exam-badge exam-badge-b');
+    const nextTag = node.isNext ? '<span class="exam-node-next">NEXT</span>' : '';
+    const customActions = node.custom
+        ? `<div class="exam-node-custom-actions">
+               <button type="button" class="exam-node-mini" data-action="edit-custom">Edit</button>
+               <button type="button" class="exam-node-mini exam-node-mini-danger" data-action="delete-custom">Delete</button>
+           </div>`
+        : '';
+
+    el.innerHTML = `
+        <span class="exam-node-accent" style="background:${accent}"></span>
+        <div class="exam-node-body">
+            <div class="exam-node-row1">
+                <span class="${badgeClass}">${escapeHtml(node.label)}</span>
+                ${nextTag}
+                <button type="button" class="exam-node-remove" data-action="remove" title="Remove from roadmap" aria-label="Remove from roadmap">&times;</button>
+            </div>
+            <div class="exam-node-name">${safeName}</div>
+            <div class="exam-node-date">${escapeHtml(formatExamDate(node.date))}</div>
+            ${customActions}
+        </div>`;
+    return el;
+}
+
+/**
+ * Builds a horizontal connector (line + optional gap chip + arrow) between two nodes.
+ * @param {Object} a - Left node.
+ * @param {Object} b - Right node.
+ * @returns {HTMLElement} Connector element.
+ */
+function buildConnector(a, b) {
+    const conn = document.createElement('div');
+    conn.className = 'exam-connector';
+    conn.setAttribute('aria-hidden', 'true');
+    const gap = gapDays(a, b);
+    const chip = gap != null ? `<span class="exam-gap-chip" title="${gap} day(s) between exams">${gap}d</span>` : '';
+    conn.innerHTML = `<span class="exam-connector-line"></span>${chip}<span class="exam-connector-arrow">${EXAM_CHEVRON_RIGHT}</span>`;
+    return conn;
+}
+
+/**
+ * Builds a row-turn connector that drops to the next row on the turning side.
+ * @param {boolean} reverse - Whether the just-completed row was reversed.
+ * @param {number|null} gap - Gap days to the first node of the next row.
+ * @returns {HTMLElement} Turn element.
+ */
+function buildTurnConnector(reverse, gap) {
+    const turn = document.createElement('div');
+    // A non-reversed row ends on the right; the next turn drops on the right.
+    turn.className = `exam-turn ${reverse ? 'exam-turn-left' : 'exam-turn-right'}`;
+    turn.setAttribute('aria-hidden', 'true');
+    const chip = gap != null ? `<span class="exam-gap-chip" title="${gap} day(s) until next exam">${gap}d</span>` : '';
+    turn.innerHTML = `<span class="exam-turn-elbow"></span>${chip}<span class="exam-turn-arrow">${EXAM_CHEVRON_DOWN}</span>`;
+    return turn;
+}
+
+/**
+ * Builds an empty placeholder cell that occupies one column so partial (last) rows
+ * keep the same grid alignment as full rows.
+ * @returns {HTMLElement} Spacer element.
+ */
+function buildSpacer() {
+    const s = document.createElement('div');
+    s.className = 'exam-spacer';
+    s.setAttribute('aria-hidden', 'true');
+    return s;
+}
+
+/**
+ * Builds an empty connector that reserves a connector's width next to a spacer cell
+ * (no visible line, arrow, or gap chip).
+ * @returns {HTMLElement} Blank connector element.
+ */
+function buildBlankConnector() {
+    const c = document.createElement('div');
+    c.className = 'exam-connector exam-connector-blank';
+    c.setAttribute('aria-hidden', 'true');
+    return c;
+}
+
+/**
+ * Builds the collapsible tray of hidden nodes with restore actions.
+ * @param {Array<Object>} hiddenNodes - Hidden annotated nodes.
+ * @returns {HTMLElement} Tray element.
+ */
+function buildHiddenTray(hiddenNodes) {
+    const tray = document.createElement('div');
+    tray.className = 'exam-hidden-tray';
+    const items = hiddenNodes.map(node => {
+        const safeName = escapeHtml(node.name) || 'Untitled exam';
+        const safeId = escapeHtml(node.id);
+        return `
+            <div class="exam-hidden-item">
+                <span class="exam-hidden-name" title="${escapeHtml(node.name)}">${safeName}</span>
+                <span class="exam-hidden-meta">${escapeHtml(node.label)} &middot; ${escapeHtml(formatExamDate(node.date))}</span>
+                <button type="button" class="exam-node-mini" data-action="restore" data-node-id="${safeId}">Restore</button>
+            </div>`;
+    }).join('');
+    tray.innerHTML = `
+        <div class="exam-hidden-title">
+            <span>Hidden (${hiddenNodes.length})</span>
+            <button type="button" class="exam-node-mini" data-action="restore-all">Restore all</button>
+        </div>
+        <div class="exam-hidden-list">${items}</div>`;
+    return tray;
+}
+
+// ============================================================================
+// RESIZE OBSERVER (responsive serpentine)
+// ============================================================================
+
+/**
+ * Observes the board's host width and re-lays-out on change (debounced via rAF).
+ * @param {HTMLElement} board - The .exam-board element.
+ * @param {Array<Object>} nodes - Nodes to re-layout.
+ */
+function setupExamResizeObserver(board, nodes) {
+    teardownExamResizeObserver();
+    if (typeof ResizeObserver === 'undefined') return;
+    let raf = null;
+    examResizeObserver = new ResizeObserver(() => {
+        if (raf) cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(() => layoutExamRows(board, nodes));
+    });
+    examResizeObserver.observe(board.parentElement || board);
+}
+
+/**
+ * Disconnects the active ResizeObserver, if any.
+ */
+function teardownExamResizeObserver() {
+    if (examResizeObserver) {
+        examResizeObserver.disconnect();
+        examResizeObserver = null;
+    }
+}
+
+// ============================================================================
+// EVENTS
+// ============================================================================
+
+/**
+ * Wires the manual toggle, delegated roadmap actions, keyboard nav, and the custom
+ * exam modal. Called once from setupEventListeners().
+ */
+function setupExamModeEvents() {
+    const toggle = $('right-view-toggle');
+    if (toggle) toggle.addEventListener('click', onViewToggleClick);
+
+    const examView = $('exam-view');
+    if (examView) {
+        examView.addEventListener('click', onExamViewClick);
+        examView.addEventListener('keydown', onExamViewKeydown);
+    }
+
+    const saveBtn = $('custom-exam-save-btn');
+    if (saveBtn) saveBtn.addEventListener('click', saveCustomExamFromModal);
+    const deleteBtn = $('custom-exam-delete-btn');
+    if (deleteBtn) deleteBtn.addEventListener('click', deleteCustomExamFromModal);
+    const hueInput = $('custom-exam-hue');
+    if (hueInput) hueInput.addEventListener('input', updateCustomExamColorPreview);
+}
+
+/**
+ * Handles clicks on the segmented Schedule | Exams | Auto toggle.
+ * @param {MouseEvent} e - Click event.
+ */
+function onViewToggleClick(e) {
+    const btn = e.target.closest('[data-view]');
+    if (!btn) return;
+    const semester = getCurrentSemester();
+    if (!semester) return;
+
+    const view = btn.dataset.view;
+    if (view === 'auto') semester.examViewMode = EXAM_VIEW_MODES.AUTO;
+    else if (view === 'semester') semester.examViewMode = EXAM_VIEW_MODES.SEMESTER;
+    else if (view === 'exam') semester.examViewMode = EXAM_VIEW_MODES.EXAM;
+    else return;
+
+    saveData();
+    renderAll();
+}
+
+/**
+ * Delegated handler for all roadmap interactions inside #exam-view.
+ * @param {MouseEvent} e - Click event.
+ */
+function onExamViewClick(e) {
+    const semester = getCurrentSemester();
+    if (!semester) return;
+
+    const filterBtn = e.target.closest('[data-filter]');
+    if (filterBtn) {
+        examMoedFilter = filterBtn.dataset.filter;
+        renderExamMode();
+        return;
+    }
+
+    const actionEl = e.target.closest('[data-action]');
+    if (actionEl) {
+        const action = actionEl.dataset.action;
+        const nodeEl = actionEl.closest('[data-node-id]');
+        const nodeId = actionEl.dataset.nodeId || (nodeEl && nodeEl.dataset.nodeId) || '';
+
+        switch (action) {
+            case 'add-custom': openCustomExamModal(semester); return;
+            case 'restore-all': handleRestoreAll(semester); return;
+            case 'remove': handleRemoveNode(semester, nodeId); return;
+            case 'restore': handleRestoreNode(semester, nodeId); return;
+            case 'edit-custom': openCustomExamModal(semester, nodeId); return;
+            case 'delete-custom': handleDeleteCustom(semester, nodeId); return;
+            default: return;
+        }
+    }
+
+    const node = e.target.closest('.exam-node');
+    if (node) openExamNode(semester, node);
+}
+
+/**
+ * Keyboard navigation across nodes (roving focus) plus Enter/Space activation.
+ * @param {KeyboardEvent} e - Keydown event.
+ */
+function onExamViewKeydown(e) {
+    const node = e.target.closest('.exam-node');
+    if (!node) return;
+
+    if (e.key === 'Enter' || e.key === ' ') {
+        if (e.target === node) {
+            e.preventDefault();
+            const semester = getCurrentSemester();
+            if (semester) openExamNode(semester, node);
+        }
+        return;
+    }
+
+    const navKeys = ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Home', 'End'];
+    if (!navKeys.includes(e.key)) return;
+    const board = node.closest('.exam-board');
+    if (!board) return;
+    e.preventDefault();
+
+    const nodes = Array.from(board.querySelectorAll('.exam-node'));
+    const idx = nodes.indexOf(node);
+    let target = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') target = Math.min(nodes.length - 1, idx + 1);
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') target = Math.max(0, idx - 1);
+    else if (e.key === 'Home') target = 0;
+    else if (e.key === 'End') target = nodes.length - 1;
+    if (nodes[target]) nodes[target].focus();
+}
+
+/**
+ * Opens the entity behind a node: the course Details tab (with the exam field
+ * highlighted) for real exams, or the custom-exam editor for custom nodes.
+ * @param {Object} semester - Semester object.
+ * @param {HTMLElement} nodeEl - The clicked node element.
+ */
+function openExamNode(semester, nodeEl) {
+    if (nodeEl.dataset.custom === '1') {
+        openCustomExamModal(semester, nodeEl.dataset.nodeId);
+        return;
+    }
+    const courseId = nodeEl.dataset.courseId;
+    const moed = nodeEl.dataset.moed;
+    if (!courseId || typeof openCourseModal !== 'function') return;
+    openCourseModal(courseId, 'details', { type: 'exam', examType: moed === 'A' ? 'moedA' : 'moedB' });
+}
+
+/**
+ * Hides a node and offers an Undo toast.
+ * @param {Object} semester - Semester object.
+ * @param {string} nodeId - Node id.
+ */
+function handleRemoveNode(semester, nodeId) {
+    if (!nodeId || !hideExamNode(semester, nodeId)) return;
+    saveData();
+    renderAll();
+    if (typeof ToastManager !== 'undefined') {
+        ToastManager.info('Exam hidden from roadmap', {
+            actionLabel: 'Undo',
+            action: () => {
+                if (restoreExamNode(semester, nodeId)) {
+                    saveData();
+                    renderAll();
+                }
+            }
+        });
+    }
+}
+
+/**
+ * Restores a single hidden node.
+ * @param {Object} semester - Semester object.
+ * @param {string} nodeId - Node id.
+ */
+function handleRestoreNode(semester, nodeId) {
+    if (restoreExamNode(semester, nodeId)) {
+        saveData();
+        renderAll();
+    }
+}
+
+/**
+ * Restores all hidden nodes.
+ * @param {Object} semester - Semester object.
+ */
+function handleRestoreAll(semester) {
+    if (clearHiddenExams(semester)) {
+        saveData();
+        renderAll();
+        if (typeof ToastManager !== 'undefined') ToastManager.success('Restored hidden exams');
+    }
+}
+
+/**
+ * Deletes a custom exam and offers an Undo toast that re-adds it verbatim.
+ * @param {Object} semester - Semester object.
+ * @param {string} customId - Custom exam id.
+ */
+function handleDeleteCustom(semester, customId) {
+    const removed = removeCustomExam(semester, customId);
+    if (!removed) return;
+    saveData();
+    renderAll();
+    if (typeof ToastManager !== 'undefined') {
+        ToastManager.info('Custom exam removed', {
+            actionLabel: 'Undo',
+            action: () => {
+                if (!Array.isArray(semester.customExams)) semester.customExams = [];
+                semester.customExams.push(removed);
+                saveData();
+                renderAll();
+            }
+        });
+    }
+}
+
+// ============================================================================
+// CUSTOM EXAM MODAL
+// ============================================================================
+
+/**
+ * Opens the custom-exam modal in add or edit mode.
+ * @param {Object} semester - Semester object.
+ * @param {string|null} [customId] - Existing custom exam id when editing.
+ */
+function openCustomExamModal(semester, customId = null) {
+    const modal = $('custom-exam-modal');
+    if (!modal) return;
+
+    const exam = customId && Array.isArray(semester.customExams)
+        ? semester.customExams.find(e => e.id === customId) || null
+        : null;
+
+    const titleEl = $('custom-exam-modal-title');
+    const idEl = $('custom-exam-id');
+    const nameEl = $('custom-exam-name');
+    const labelEl = $('custom-exam-label');
+    const dateEl = $('custom-exam-date');
+    const hueEl = $('custom-exam-hue');
+    const deleteBtn = $('custom-exam-delete-btn');
+
+    if (idEl) idEl.value = exam ? exam.id : '';
+    if (nameEl) nameEl.value = exam ? exam.name : '';
+    if (labelEl) labelEl.value = exam ? exam.label : '';
+    if (dateEl) dateEl.value = exam ? exam.date : '';
+    if (hueEl) hueEl.value = exam && exam.color ? extractHueFromColor(exam.color) : 200;
+    updateCustomExamColorPreview();
+    if (titleEl) titleEl.textContent = exam ? 'Edit Custom Exam' : 'Add Custom Exam';
+    if (deleteBtn) deleteBtn.style.display = exam ? '' : 'none';
+
+    openModal('custom-exam-modal');
+    if (nameEl) setTimeout(() => nameEl.focus(), 50);
+}
+
+/**
+ * Updates the modal color swatch from the hue slider.
+ */
+function updateCustomExamColorPreview() {
+    const hueEl = $('custom-exam-hue');
+    const preview = $('custom-exam-color-preview');
+    if (!hueEl || !preview) return;
+    preview.style.backgroundColor = `hsl(${hueEl.value}, 45%, 50%)`;
+}
+
+/**
+ * Saves the custom-exam modal (add or update) with validation feedback.
+ */
+function saveCustomExamFromModal() {
+    const semester = getCurrentSemester();
+    if (!semester) {
+        if (typeof ToastManager !== 'undefined') ToastManager.error('No semester selected');
+        return;
+    }
+    const id = $('custom-exam-id') ? $('custom-exam-id').value : '';
+    const hue = $('custom-exam-hue') ? $('custom-exam-hue').value : 200;
+    const data = {
+        name: $('custom-exam-name') ? $('custom-exam-name').value : '',
+        label: $('custom-exam-label') ? $('custom-exam-label').value : '',
+        date: $('custom-exam-date') ? $('custom-exam-date').value : '',
+        color: `hsl(${hue}, 45%, 50%)`
+    };
+
+    const result = id ? updateCustomExam(semester, id, data) : addCustomExam(semester, data);
+    if (result && result.error) {
+        if (typeof ToastManager !== 'undefined') ToastManager.error(result.error);
+        return;
+    }
+
+    saveData();
+    renderAll();
+    closeModal('custom-exam-modal');
+    if (typeof ToastManager !== 'undefined') {
+        ToastManager.success(id ? 'Custom exam updated' : 'Custom exam added');
+    }
+}
+
+/**
+ * Deletes the custom exam currently open in the modal.
+ */
+function deleteCustomExamFromModal() {
+    const semester = getCurrentSemester();
+    const idEl = $('custom-exam-id');
+    if (!semester || !idEl || !idEl.value) return;
+    handleDeleteCustom(semester, idEl.value);
+    closeModal('custom-exam-modal');
+}
+
+// ============================================================================
+// GLOBAL EXPORTS
+// Top-level function declarations are already global in classic scripts; these
+// explicit assignments also expose the API to the eval-based Jest harness.
+// ============================================================================
+
+if (typeof window !== 'undefined') {
+    // Integration entry points (render.js / events.js).
+    window.renderExamMode = renderExamMode;
+    window.setupExamModeEvents = setupExamModeEvents;
+    // Persistence helpers (state.js).
+    window.compactExamMode = compactExamMode;
+    window.hydrateExamMode = hydrateExamMode;
+    // Pure logic (tests + debugging).
+    window.parseExamDate = parseExamDate;
+    window.daysBetween = daysBetween;
+    window.daysUntil = daysUntil;
+    window.formatExamDate = formatExamDate;
+    window.examNodeId = examNodeId;
+    window.collectExams = collectExams;
+    window.getExamWindow = getExamWindow;
+    window.isExamModeActiveByDate = isExamModeActiveByDate;
+    window.resolveExamViewMode = resolveExamViewMode;
+    window.annotateExamStates = annotateExamStates;
+    window.gapDays = gapDays;
+    window.hideExamNode = hideExamNode;
+    window.restoreExamNode = restoreExamNode;
+    window.clearHiddenExams = clearHiddenExams;
+    window.validateCustomExam = validateCustomExam;
+    window.addCustomExam = addCustomExam;
+    window.updateCustomExam = updateCustomExam;
+    window.removeCustomExam = removeCustomExam;
+    window.computeExamColumns = computeExamColumns;
+    window.chunkExams = chunkExams;
+    window.buildRowCells = buildRowCells;
+    window.cssColor = cssColor;
+    // Inline-free modal handlers (wired via addEventListener; exported for parity).
+    window.openCustomExamModal = openCustomExamModal;
+}

--- a/js/render.js
+++ b/js/render.js
@@ -22,6 +22,11 @@ function renderAll() {
     if (typeof renderHeaderTicker === 'function') {
         renderHeaderTicker();
     }
+
+    // Exam Mode is implemented in js/exam-mode.js (swaps the right column)
+    if (typeof renderExamMode === 'function') {
+        renderExamMode();
+    }
 }
 
 /**

--- a/js/state.js
+++ b/js/state.js
@@ -119,6 +119,12 @@ function compactSemester(semester) {
         if (Object.keys(calCompact).length > 0) compact.cal = calCompact;
     }
     
+    // Exam-mode fields (view override, hidden ids, custom exams) - only if non-default
+    if (typeof compactExamMode === 'function') {
+        const exam = compactExamMode(semester);
+        if (exam) Object.assign(compact, exam);
+    }
+    
     return compact;
 }
 
@@ -260,6 +266,15 @@ function hydrateSemester(s) {
         if (s.cal.vd) semester.calendarSettings.visibleDays = s.cal.vd;
     }
     
+    // Exam-mode fields (defaults applied when absent)
+    if (typeof hydrateExamMode === 'function') {
+        Object.assign(semester, hydrateExamMode(s));
+    } else {
+        semester.examViewMode = 'auto';
+        semester.hiddenExamIds = [];
+        semester.customExams = [];
+    }
+    
     return semester;
 }
 
@@ -366,6 +381,10 @@ function migrateData(data) {
         if (!semester.calendarSettings) {
             semester.calendarSettings = { ...DEFAULT_CALENDAR_SETTINGS };
         }
+        // Exam-mode fields (preserve existing, default when absent)
+        if (!semester.examViewMode) semester.examViewMode = 'auto';
+        if (!Array.isArray(semester.hiddenExamIds)) semester.hiddenExamIds = [];
+        if (!Array.isArray(semester.customExams)) semester.customExams = [];
         semester.courses.forEach(migrateCourse);
     });
     

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint js/*.js",
     "lint:fix": "eslint js/*.js --fix",
-    "serve": "npx http-server -p 8080 -o",
+    "serve": "npx http-server -p 8080 -o -c-1",
     "validate": "html-validate index.html"
   },
   "repository": {
@@ -28,9 +28,9 @@
     "@babel/core": "^7.23.0",
     "@babel/preset-env": "^7.23.0",
     "eslint": "^8.53.0",
+    "html-validate": "^8.7.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
-    "html-validate": "^8.7.0"
+    "jest-environment-jsdom": "^29.7.0"
   },
   "jest": {
     "testEnvironment": "jsdom",
@@ -51,7 +51,7 @@
       "<rootDir>/tests/setup.js"
     ],
     "testMatch": [
-      "<rootDir>/tests/**/*.test.js"
+      "**/tests/**/*.test.js"
     ],
     "moduleFileExtensions": [
       "js"

--- a/tests/exam-mode.test.js
+++ b/tests/exam-mode.test.js
@@ -1,0 +1,501 @@
+/**
+ * @fileoverview Unit tests for js/exam-mode.js (pure logic + persistence round-trip).
+ *
+ * exam-mode.js runs in strict mode, so a direct eval() does not leak its function
+ * declarations into this module's scope. The module assigns its public API to
+ * `window` (jsdom), so we destructure the functions from `window` after eval.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Deterministic id generator used by addCustomExam (provided before eval so the
+// strict-mode functions resolve it through the global scope chain).
+let __idCounter = 0;
+global.generateId = () => `cx${++__idCounter}`;
+
+const examModeCode = fs.readFileSync(path.join(__dirname, '../js/exam-mode.js'), 'utf8');
+// eslint-disable-next-line no-eval
+eval(examModeCode);
+
+const {
+    parseExamDate,
+    daysBetween,
+    daysUntil,
+    formatExamDate,
+    examNodeId,
+    collectExams,
+    getExamWindow,
+    isExamModeActiveByDate,
+    resolveExamViewMode,
+    annotateExamStates,
+    gapDays,
+    hideExamNode,
+    restoreExamNode,
+    clearHiddenExams,
+    validateCustomExam,
+    addCustomExam,
+    updateCustomExam,
+    removeCustomExam,
+    compactExamMode,
+    hydrateExamMode,
+    computeExamColumns,
+    chunkExams,
+    buildRowCells,
+    cssColor
+} = window;
+
+beforeEach(() => {
+    __idCounter = 0;
+});
+
+// ----------------------------------------------------------------------------
+// Test factories
+// ----------------------------------------------------------------------------
+
+function makeCourse(id, name, moedA = '', moedB = '', color = 'hsl(10, 45%, 50%)') {
+    return { id, name, color, exams: { moedA, moedB } };
+}
+
+function makeSemester(courses = [], extra = {}) {
+    return Object.assign(
+        { id: 's1', name: 'Spring 2026', courses, hiddenExamIds: [], customExams: [], examViewMode: 'auto' },
+        extra
+    );
+}
+
+function makeExams(dates) {
+    return dates.map(d => ({ dateObj: parseExamDate(d), date: d }));
+}
+
+// ----------------------------------------------------------------------------
+// Date helpers
+// ----------------------------------------------------------------------------
+
+describe('parseExamDate', () => {
+    test('parses a valid date at local midnight', () => {
+        const d = parseExamDate('2026-06-14');
+        expect(d).toBeInstanceOf(Date);
+        expect(d.getFullYear()).toBe(2026);
+        expect(d.getMonth()).toBe(5);
+        expect(d.getDate()).toBe(14);
+        expect(d.getHours()).toBe(0);
+        expect(d.getMinutes()).toBe(0);
+    });
+
+    test('returns null for empty / non-string / malformed input', () => {
+        expect(parseExamDate('')).toBeNull();
+        expect(parseExamDate(null)).toBeNull();
+        expect(parseExamDate(undefined)).toBeNull();
+        expect(parseExamDate('14-06-2026')).toBeNull();
+        expect(parseExamDate('not-a-date')).toBeNull();
+    });
+
+    test('returns null for impossible calendar dates (rollover)', () => {
+        expect(parseExamDate('2026-02-31')).toBeNull();
+        expect(parseExamDate('2026-13-01')).toBeNull();
+    });
+});
+
+describe('daysBetween / daysUntil', () => {
+    test('counts whole days across a month boundary', () => {
+        expect(daysBetween(new Date(2026, 5, 1), new Date(2026, 5, 30))).toBe(29);
+    });
+
+    test('is zero for the same day and signed by direction', () => {
+        expect(daysBetween(new Date(2026, 5, 10), new Date(2026, 5, 10))).toBe(0);
+        expect(daysBetween(new Date(2026, 5, 12), new Date(2026, 5, 10))).toBe(-2);
+    });
+
+    test('ignores time-of-day (local midnight normalization)', () => {
+        const a = new Date(2026, 5, 10, 23, 59);
+        const b = new Date(2026, 5, 11, 0, 1);
+        expect(daysBetween(a, b)).toBe(1);
+    });
+
+    test('daysUntil is relative to a reference date and null for invalid input', () => {
+        const today = new Date(2026, 5, 10);
+        expect(daysUntil('2026-06-15', today)).toBe(5);
+        expect(daysUntil('2026-06-05', today)).toBe(-5);
+        expect(daysUntil('bad', today)).toBeNull();
+    });
+});
+
+describe('formatExamDate', () => {
+    test('formats compactly as "Day, D Mon"', () => {
+        const dn = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][new Date(2026, 5, 14).getDay()];
+        expect(formatExamDate('2026-06-14')).toBe(`${dn}, 14 Jun`);
+    });
+
+    test('returns empty string for invalid input', () => {
+        expect(formatExamDate('')).toBe('');
+        expect(formatExamDate('2026-02-31')).toBe('');
+    });
+});
+
+// ----------------------------------------------------------------------------
+// Collection & sort
+// ----------------------------------------------------------------------------
+
+describe('examNodeId', () => {
+    test('builds stable ids from course id and moed', () => {
+        expect(examNodeId('abc', 'A')).toBe('abc:A');
+        expect(examNodeId('abc', 'B')).toBe('abc:B');
+    });
+});
+
+describe('collectExams', () => {
+    test('collects Moed A and Moed B nodes, sorted ascending by date', () => {
+        const sem = makeSemester([
+            makeCourse('c1', 'Algebra', '2026-06-20', '2026-07-10'),
+            makeCourse('c2', 'Physics', '2026-06-15', '')
+        ]);
+        const nodes = collectExams(sem);
+        expect(nodes.map(n => n.date)).toEqual(['2026-06-15', '2026-06-20', '2026-07-10']);
+        expect(nodes[0]).toMatchObject({ courseId: 'c2', moed: 'A', custom: false, label: 'Moed A' });
+        expect(nodes[2]).toMatchObject({ courseId: 'c1', moed: 'B', label: 'Moed B' });
+    });
+
+    test('excludes empty and invalid exam dates', () => {
+        const sem = makeSemester([
+            makeCourse('c1', 'Algebra', '', ''),
+            makeCourse('c2', 'Physics', '2026-13-40', '2026-06-15')
+        ]);
+        const nodes = collectExams(sem);
+        expect(nodes).toHaveLength(1);
+        expect(nodes[0].date).toBe('2026-06-15');
+    });
+
+    test('includes custom exams flagged as custom', () => {
+        const sem = makeSemester(
+            [makeCourse('c1', 'Algebra', '2026-06-20')],
+            { customExams: [{ id: 'x1', name: 'Lab safety', label: 'Quiz', date: '2026-06-10', color: '' }] }
+        );
+        const nodes = collectExams(sem);
+        expect(nodes[0]).toMatchObject({ id: 'x1', custom: true, label: 'Quiz', courseId: null });
+        expect(nodes.map(n => n.date)).toEqual(['2026-06-10', '2026-06-20']);
+    });
+
+    test('keeps duplicate-dated exams (stable), real before custom', () => {
+        const sem = makeSemester(
+            [makeCourse('c1', 'Algebra', '2026-06-20')],
+            { customExams: [{ id: 'x1', name: 'Extra', label: 'Quiz', date: '2026-06-20', color: '' }] }
+        );
+        const nodes = collectExams(sem);
+        expect(nodes).toHaveLength(2);
+        expect(nodes[0].custom).toBe(false);
+        expect(nodes[1].custom).toBe(true);
+    });
+
+    test('hides nodes in hiddenExamIds by default but reveals them with includeHidden', () => {
+        const sem = makeSemester([makeCourse('c1', 'Algebra', '2026-06-20', '2026-07-10')], {
+            hiddenExamIds: ['c1:A']
+        });
+        expect(collectExams(sem).map(n => n.id)).toEqual(['c1:B']);
+        const all = collectExams(sem, { includeHidden: true });
+        expect(all.map(n => n.id)).toEqual(['c1:A', 'c1:B']);
+        expect(all.find(n => n.id === 'c1:A').hidden).toBe(true);
+    });
+});
+
+// ----------------------------------------------------------------------------
+// View-mode decision
+// ----------------------------------------------------------------------------
+
+describe('getExamWindow', () => {
+    test('returns null when there are no exams', () => {
+        expect(getExamWindow([])).toBeNull();
+    });
+
+    test('returns first/last bounds', () => {
+        const win = getExamWindow(makeExams(['2026-06-20', '2026-06-10', '2026-07-01']));
+        expect(win.first.getTime()).toBe(parseExamDate('2026-06-10').getTime());
+        expect(win.last.getTime()).toBe(parseExamDate('2026-07-01').getTime());
+    });
+});
+
+describe('isExamModeActiveByDate', () => {
+    const exams = makeExams(['2026-06-20', '2026-07-04']);
+
+    test('is false when there are no exams', () => {
+        expect(isExamModeActiveByDate([], new Date(2026, 5, 20), 14)).toBe(false);
+    });
+
+    test('is true inside the window', () => {
+        expect(isExamModeActiveByDate(exams, new Date(2026, 5, 25), 14)).toBe(true);
+    });
+
+    test('is true exactly at firstExam - leadDays (inclusive lower bound)', () => {
+        expect(isExamModeActiveByDate(exams, new Date(2026, 5, 6), 14)).toBe(true); // Jun 20 - 14 = Jun 6
+    });
+
+    test('is false the day before the lead window opens', () => {
+        expect(isExamModeActiveByDate(exams, new Date(2026, 5, 5), 14)).toBe(false);
+    });
+
+    test('is true exactly on the last exam day and false the day after', () => {
+        expect(isExamModeActiveByDate(exams, new Date(2026, 6, 4), 14)).toBe(true);
+        expect(isExamModeActiveByDate(exams, new Date(2026, 6, 5), 14)).toBe(false);
+    });
+});
+
+describe('resolveExamViewMode', () => {
+    const sem = makeSemester([makeCourse('c1', 'Algebra', '2026-06-20')]);
+    const insideWindow = new Date(2026, 5, 15);
+    const outsideWindow = new Date(2026, 0, 1);
+
+    test('auto resolves to exam inside the window and semester outside it', () => {
+        expect(resolveExamViewMode(makeSemester([makeCourse('c1', 'A', '2026-06-20')]), insideWindow, 14)).toBe('exam');
+        expect(resolveExamViewMode(makeSemester([makeCourse('c1', 'A', '2026-06-20')]), outsideWindow, 14)).toBe('semester');
+    });
+
+    test('manual override wins over the date decision', () => {
+        const forcedExam = makeSemester([makeCourse('c1', 'A', '2026-06-20')], { examViewMode: 'exam' });
+        const forcedSem = makeSemester([makeCourse('c1', 'A', '2026-06-20')], { examViewMode: 'semester' });
+        expect(resolveExamViewMode(forcedExam, outsideWindow, 14)).toBe('exam');
+        expect(resolveExamViewMode(forcedSem, insideWindow, 14)).toBe('semester');
+    });
+
+    test('auto with no exams resolves to semester', () => {
+        expect(resolveExamViewMode(makeSemester([]), insideWindow, 14)).toBe('semester');
+    });
+});
+
+describe('annotateExamStates', () => {
+    test('classifies passed / today / upcoming and marks the next exam', () => {
+        const today = new Date(2026, 5, 10);
+        const nodes = collectExams(makeSemester([
+            makeCourse('c1', 'Past', '2026-06-01'),
+            makeCourse('c2', 'Today', '2026-06-10'),
+            makeCourse('c3', 'Future', '2026-06-20')
+        ]));
+        const annotated = annotateExamStates(nodes, today);
+        expect(annotated.map(n => n.state)).toEqual(['passed', 'today', 'upcoming']);
+        expect(annotated.map(n => n.isNext)).toEqual([false, true, false]);
+    });
+
+    test('marks no next when every exam has passed', () => {
+        const today = new Date(2026, 11, 1);
+        const nodes = collectExams(makeSemester([makeCourse('c1', 'Old', '2026-06-01')]));
+        const annotated = annotateExamStates(nodes, today);
+        expect(annotated.every(n => !n.isNext)).toBe(true);
+        expect(annotated[0].state).toBe('passed');
+    });
+});
+
+describe('gapDays', () => {
+    test('returns the absolute day gap between two nodes', () => {
+        const [a, b] = makeExams(['2026-06-10', '2026-06-17']);
+        expect(gapDays(a, b)).toBe(7);
+        expect(gapDays(b, a)).toBe(7);
+    });
+
+    test('returns null when a node lacks a date', () => {
+        expect(gapDays({ dateObj: null }, makeExams(['2026-06-10'])[0])).toBeNull();
+    });
+});
+
+// ----------------------------------------------------------------------------
+// Hide / restore (non-destructive)
+// ----------------------------------------------------------------------------
+
+describe('hide / restore', () => {
+    test('hideExamNode is idempotent and never touches course exam data', () => {
+        const course = makeCourse('c1', 'Algebra', '2026-06-20', '2026-07-10');
+        const sem = makeSemester([course]);
+        expect(hideExamNode(sem, 'c1:A')).toBe(true);
+        expect(hideExamNode(sem, 'c1:A')).toBe(false);
+        expect(sem.hiddenExamIds).toEqual(['c1:A']);
+        // underlying exam dates are untouched
+        expect(course.exams).toEqual({ moedA: '2026-06-20', moedB: '2026-07-10' });
+    });
+
+    test('restoreExamNode removes a hidden id and reports change', () => {
+        const sem = makeSemester([], { hiddenExamIds: ['c1:A'] });
+        expect(restoreExamNode(sem, 'c1:A')).toBe(true);
+        expect(restoreExamNode(sem, 'c1:A')).toBe(false);
+        expect(sem.hiddenExamIds).toEqual([]);
+    });
+
+    test('clearHiddenExams empties the set when non-empty', () => {
+        const sem = makeSemester([], { hiddenExamIds: ['a', 'b'] });
+        expect(clearHiddenExams(sem)).toBe(true);
+        expect(sem.hiddenExamIds).toEqual([]);
+        expect(clearHiddenExams(sem)).toBe(false);
+    });
+});
+
+// ----------------------------------------------------------------------------
+// Custom exams
+// ----------------------------------------------------------------------------
+
+describe('validateCustomExam', () => {
+    test('requires a name', () => {
+        expect(validateCustomExam({ name: '', date: '2026-06-10' }).valid).toBe(false);
+    });
+
+    test('requires a valid date', () => {
+        expect(validateCustomExam({ name: 'X', date: '' }).valid).toBe(false);
+        expect(validateCustomExam({ name: 'X', date: '10/06/2026' }).valid).toBe(false);
+    });
+
+    test('trims fields and clamps the label length', () => {
+        const res = validateCustomExam({ name: '  Final  ', label: 'x'.repeat(40), date: '2026-06-10' });
+        expect(res.valid).toBe(true);
+        expect(res.value.name).toBe('Final');
+        expect(res.value.label.length).toBe(30);
+    });
+});
+
+describe('addCustomExam / updateCustomExam / removeCustomExam', () => {
+    test('addCustomExam appends a normalized exam with an id', () => {
+        const sem = makeSemester();
+        const created = addCustomExam(sem, { name: 'Lab', label: 'Quiz', date: '2026-06-10', color: 'hsl(200,45%,50%)' });
+        expect(created.id).toBeTruthy();
+        expect(sem.customExams).toHaveLength(1);
+        expect(sem.customExams[0]).toMatchObject({ name: 'Lab', label: 'Quiz', date: '2026-06-10' });
+    });
+
+    test('addCustomExam rejects invalid input', () => {
+        const sem = makeSemester();
+        expect(addCustomExam(sem, { name: '', date: '2026-06-10' }).error).toBeTruthy();
+        expect(sem.customExams).toHaveLength(0);
+    });
+
+    test('updateCustomExam edits an existing exam and validates', () => {
+        const sem = makeSemester();
+        const created = addCustomExam(sem, { name: 'Lab', date: '2026-06-10' });
+        const updated = updateCustomExam(sem, created.id, { name: 'Lab 2', date: '2026-06-12' });
+        expect(updated).toMatchObject({ name: 'Lab 2', date: '2026-06-12' });
+        expect(updateCustomExam(sem, created.id, { date: 'bad' }).error).toBeTruthy();
+        expect(updateCustomExam(sem, 'missing', { name: 'x' }).error).toBeTruthy();
+    });
+
+    test('removeCustomExam returns the removed exam and clears any hidden id', () => {
+        const sem = makeSemester();
+        const created = addCustomExam(sem, { name: 'Lab', date: '2026-06-10' });
+        hideExamNode(sem, created.id);
+        const removed = removeCustomExam(sem, created.id);
+        expect(removed).toMatchObject({ name: 'Lab' });
+        expect(sem.customExams).toHaveLength(0);
+        expect(sem.hiddenExamIds).not.toContain(created.id);
+        expect(removeCustomExam(sem, 'missing')).toBeNull();
+    });
+});
+
+// ----------------------------------------------------------------------------
+// Persistence round-trip (compact <-> hydrate)
+// ----------------------------------------------------------------------------
+
+describe('compactExamMode / hydrateExamMode', () => {
+    test('returns undefined when all fields are default', () => {
+        expect(compactExamMode(makeSemester())).toBeUndefined();
+        expect(compactExamMode({ examViewMode: 'auto', hiddenExamIds: [], customExams: [] })).toBeUndefined();
+    });
+
+    test('compacts only non-default fields and omits empty custom color/label', () => {
+        const sem = makeSemester([], {
+            examViewMode: 'exam',
+            hiddenExamIds: ['c1:A'],
+            customExams: [{ id: 'x1', name: 'Lab', label: '', date: '2026-06-10', color: '' }]
+        });
+        const compact = compactExamMode(sem);
+        expect(compact).toEqual({
+            vm: 'exam',
+            hx: ['c1:A'],
+            cx: [{ i: 'x1', n: 'Lab', d: '2026-06-10' }]
+        });
+    });
+
+    test('round-trips through hydrate with defaults filled', () => {
+        const sem = makeSemester([], {
+            examViewMode: 'semester',
+            hiddenExamIds: ['c1:A', 'c2:B'],
+            customExams: [{ id: 'x1', name: 'Lab', label: 'Quiz', date: '2026-06-10', color: 'hsl(200,45%,50%)' }]
+        });
+        const restored = hydrateExamMode(compactExamMode(sem));
+        expect(restored.examViewMode).toBe('semester');
+        expect(restored.hiddenExamIds).toEqual(['c1:A', 'c2:B']);
+        expect(restored.customExams).toEqual(sem.customExams);
+    });
+
+    test('hydrateExamMode fills defaults for missing / empty input', () => {
+        expect(hydrateExamMode(undefined)).toEqual({ examViewMode: 'auto', hiddenExamIds: [], customExams: [] });
+        expect(hydrateExamMode({})).toEqual({ examViewMode: 'auto', hiddenExamIds: [], customExams: [] });
+    });
+});
+
+// ----------------------------------------------------------------------------
+// Layout helpers
+// ----------------------------------------------------------------------------
+
+describe('computeExamColumns', () => {
+    test('clamps to node count and the max column cap', () => {
+        expect(computeExamColumns(2000, 3)).toBe(3); // limited by count
+        expect(computeExamColumns(2000, 20)).toBe(6); // limited by EXAM_MAX_COLUMNS
+    });
+
+    test('derives columns from width and never returns less than one', () => {
+        expect(computeExamColumns(640, 10)).toBe(4); // floor(640 / 150)
+        expect(computeExamColumns(0, 10)).toBe(6); // unknown width -> max by count (capped)
+        expect(computeExamColumns(100, 10)).toBe(1);
+    });
+});
+
+describe('chunkExams', () => {
+    test('splits an array into rows', () => {
+        expect(chunkExams([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    });
+
+    test('treats a non-positive size as one per row', () => {
+        expect(chunkExams([1, 2], 0)).toEqual([[1], [2]]);
+    });
+});
+
+describe('buildRowCells (partial-row alignment)', () => {
+    const a = { id: 'a' };
+    const b = { id: 'b' };
+    const c = { id: 'c' };
+
+    test('full rows are unchanged forward and reversed for display', () => {
+        expect(buildRowCells([a, b, c], 3, false)).toEqual([a, b, c]);
+        expect(buildRowCells([a, b, c], 3, true)).toEqual([c, b, a]);
+    });
+
+    test('a left-to-right partial row is padded with spacers on the right', () => {
+        expect(buildRowCells([a, b], 3, false)).toEqual([a, b, null]);
+        expect(buildRowCells([a], 3, false)).toEqual([a, null, null]);
+    });
+
+    test('a reversed partial row is padded on the left, flow-first node in the last column', () => {
+        // sorted [a, b] displays reversed as [b, a]; flow-first a must land in the last column
+        const cells = buildRowCells([a, b], 3, true);
+        expect(cells).toEqual([null, b, a]);
+        expect(cells[cells.length - 1]).toBe(a);
+        expect(buildRowCells([a], 3, true)).toEqual([null, null, a]);
+    });
+
+    test('single-column rows need no padding', () => {
+        expect(buildRowCells([a], 1, false)).toEqual([a]);
+    });
+});
+
+// ----------------------------------------------------------------------------
+// Security: color sanitization for inline styles
+// ----------------------------------------------------------------------------
+
+describe('cssColor', () => {
+    test('passes through safe color formats', () => {
+        expect(cssColor('hsl(200, 45%, 50%)')).toBe('hsl(200, 45%, 50%)');
+        expect(cssColor('#1a1a1a')).toBe('#1a1a1a');
+        expect(cssColor('rgb(10, 20, 30)')).toBe('rgb(10, 20, 30)');
+        expect(cssColor('red')).toBe('red');
+    });
+
+    test('falls back to the accent token for unsafe / malformed values', () => {
+        expect(cssColor('red; background:url(x)')).toBe('var(--accent)');
+        expect(cssColor('"></span><script>alert(1)</script>')).toBe('var(--accent)');
+        expect(cssColor('')).toBe('var(--accent)');
+        expect(cssColor(null)).toBe('var(--accent)');
+    });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -5,6 +5,16 @@
 const fs = require('fs');
 const path = require('path');
 
+// HTML entity map used by escapeHtml (lives in constants.js at runtime; provided
+// here because the strict-mode constants module is not eval'd into this scope).
+global.HTML_ENTITIES = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+};
+
 // Load the utils module
 const utilsCode = fs.readFileSync(
     path.join(__dirname, '../js/utils.js'),
@@ -50,136 +60,135 @@ describe('escapeHtml', () => {
     });
 });
 
-describe('generateUUID', () => {
-    test('should generate valid UUID format', () => {
-        const uuid = generateUUID();
-        const uuidPattern = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
-        expect(uuid).toMatch(uuidPattern);
+describe('generateId', () => {
+    test('returns a non-empty string', () => {
+        const id = generateId();
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThan(0);
     });
 
-    test('should generate unique UUIDs', () => {
-        const uuids = new Set();
-        for (let i = 0; i < 100; i++) {
-            uuids.add(generateUUID());
-        }
-        expect(uuids.size).toBe(100);
+    test('generates unique ids across many calls', () => {
+        const ids = new Set();
+        for (let i = 0; i < 200; i++) ids.add(generateId());
+        expect(ids.size).toBe(200);
     });
 });
 
-describe('formatDate', () => {
-    test('should format date correctly', () => {
-        const date = new Date('2024-01-15');
-        const formatted = formatDate(date);
-        expect(formatted).toBe('2024-01-15');
+describe('truncate', () => {
+    test('does not truncate when within the limit', () => {
+        expect(truncate('Hello', 10)).toBe('Hello');
     });
 
-    test('should handle single digit month and day', () => {
-        const date = new Date('2024-01-05');
-        const formatted = formatDate(date);
-        expect(formatted).toBe('2024-01-05');
+    test('truncates long text with an ellipsis character', () => {
+        expect(truncate('Hello World', 5)).toBe('Hell\u2026');
+    });
+
+    test('treats the boundary length as not truncated', () => {
+        expect(truncate('Hello', 5)).toBe('Hello');
+    });
+
+    test('returns empty input unchanged', () => {
+        expect(truncate('', 10)).toBe('');
     });
 });
 
-describe('throttle', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
+describe('convertDateFormat', () => {
+    test('converts dd-MM-yyyy to yyyy-MM-dd', () => {
+        expect(convertDateFormat('25-12-2024')).toBe('2024-12-25');
     });
 
-    afterEach(() => {
-        jest.useRealTimers();
-    });
-
-    test('should call function immediately first time', () => {
-        const fn = jest.fn();
-        const throttled = throttle(fn, 100);
-        
-        throttled();
-        expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    test('should throttle subsequent calls', () => {
-        const fn = jest.fn();
-        const throttled = throttle(fn, 100);
-        
-        throttled();
-        throttled();
-        throttled();
-        
-        expect(fn).toHaveBeenCalledTimes(1);
-        
-        jest.advanceTimersByTime(100);
-        
-        throttled();
-        expect(fn).toHaveBeenCalledTimes(2);
+    test('returns ISO and empty values unchanged', () => {
+        expect(convertDateFormat('2024-12-25')).toBe('2024-12-25');
+        expect(convertDateFormat('')).toBe('');
     });
 });
 
-describe('debounce', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
+describe('getDayOfWeekFromDate', () => {
+    test('returns the weekday index for a valid date', () => {
+        expect(getDayOfWeekFromDate('2024-01-07')).toBe(new Date('2024-01-07').getDay());
     });
 
-    afterEach(() => {
-        jest.useRealTimers();
-    });
-
-    test('should delay function execution', () => {
-        const fn = jest.fn();
-        const debounced = debounce(fn, 100);
-        
-        debounced();
-        expect(fn).not.toHaveBeenCalled();
-        
-        jest.advanceTimersByTime(100);
-        expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    test('should reset timer on subsequent calls', () => {
-        const fn = jest.fn();
-        const debounced = debounce(fn, 100);
-        
-        debounced();
-        jest.advanceTimersByTime(50);
-        debounced();
-        jest.advanceTimersByTime(50);
-        
-        expect(fn).not.toHaveBeenCalled();
-        
-        jest.advanceTimersByTime(50);
-        expect(fn).toHaveBeenCalledTimes(1);
+    test('returns -1 for empty input', () => {
+        expect(getDayOfWeekFromDate('')).toBe(-1);
     });
 });
 
-describe('getContrastColor', () => {
-    test('should return black for light background', () => {
-        expect(getContrastColor('#FFFFFF')).toBe('#000000');
-        expect(getContrastColor('#FFFF00')).toBe('#000000');
-    });
-
-    test('should return white for dark background', () => {
-        expect(getContrastColor('#000000')).toBe('#FFFFFF');
-        expect(getContrastColor('#0000FF')).toBe('#FFFFFF');
-    });
-
-    test('should handle colors without hash', () => {
-        expect(getContrastColor('FFFFFF')).toBe('#000000');
+describe('parseICSDate', () => {
+    test('parses an ICS timestamp into date parts', () => {
+        const d = parseICSDate('20241027T103000');
+        expect(d.getFullYear()).toBe(2024);
+        expect(d.getMonth()).toBe(9);
+        expect(d.getDate()).toBe(27);
+        expect(d.getHours()).toBe(10);
+        expect(d.getMinutes()).toBe(30);
     });
 });
 
-describe('truncateText', () => {
-    test('should not truncate short text', () => {
-        expect(truncateText('Hello', 10)).toBe('Hello');
+describe('semester ordering', () => {
+    test('extractYear returns a 4-digit year or 0', () => {
+        expect(extractYear('Spring 2026')).toBe(2026);
+        expect(extractYear('No year here')).toBe(0);
     });
 
-    test('should truncate long text with ellipsis', () => {
-        expect(truncateText('Hello World', 5)).toBe('Hello...');
+    test('getSeasonValue ranks winter > summer > spring', () => {
+        expect(getSeasonValue('Winter 2026')).toBeGreaterThan(getSeasonValue('Summer 2026'));
+        expect(getSeasonValue('Summer 2026')).toBeGreaterThan(getSeasonValue('Spring 2026'));
     });
 
-    test('should handle empty string', () => {
-        expect(truncateText('', 10)).toBe('');
-    });
-
-    test('should handle exact length', () => {
-        expect(truncateText('Hello', 5)).toBe('Hello');
+    test('compareSemesters sorts newest first', () => {
+        const sems = [{ name: 'Spring 2025' }, { name: 'Winter 2026' }, { name: 'Spring 2026' }];
+        const sorted = [...sems].sort(compareSemesters).map(s => s.name);
+        expect(sorted).toEqual(['Winter 2026', 'Spring 2026', 'Spring 2025']);
     });
 });
+
+describe('extractHueFromColor', () => {
+    test('extracts the hue from an hsl string', () => {
+        expect(extractHueFromColor('hsl(180, 45%, 50%)')).toBe('180');
+    });
+
+    test('falls back to 0 when there is no hue', () => {
+        expect(extractHueFromColor('red')).toBe('0');
+    });
+});
+
+describe('detectVideoPlatform', () => {
+    test('detects youtube, panopto, and unknown sources', () => {
+        expect(detectVideoPlatform('https://www.youtube.com/watch?v=abc')).toBe('youtube');
+        expect(detectVideoPlatform('https://youtu.be/abc')).toBe('youtube');
+        expect(detectVideoPlatform('https://x.panopto.com/Pages/Viewer.aspx?id=1')).toBe('panopto');
+        expect(detectVideoPlatform('https://example.com/v')).toBe('unknown');
+        expect(detectVideoPlatform('')).toBe('unknown');
+    });
+});
+
+describe('getVideoEmbedInfo / supportsInlinePreview', () => {
+    test('builds a YouTube embed url from watch and short links', () => {
+        expect(getVideoEmbedInfo('https://www.youtube.com/watch?v=abc123').embedUrl)
+            .toBe('https://www.youtube.com/embed/abc123');
+        expect(getVideoEmbedInfo('https://youtu.be/abc123').embedUrl)
+            .toBe('https://www.youtube.com/embed/abc123');
+    });
+
+    test('reports no embed url for unknown platforms', () => {
+        expect(getVideoEmbedInfo('https://example.com/v').embedUrl).toBeNull();
+        expect(supportsInlinePreview('https://example.com/v')).toBe(false);
+        expect(supportsInlinePreview('https://youtu.be/abc123')).toBe(true);
+    });
+});
+
+describe('week range helpers', () => {
+    test('getCurrentWeekRange spans Sunday to Saturday', () => {
+        const { start, end } = getCurrentWeekRange();
+        expect(start.getDay()).toBe(0);
+        expect(end.getDay()).toBe(6);
+        expect(end.getTime()).toBeGreaterThan(start.getTime());
+    });
+
+    test('isDateInCurrentWeek is false for empty and far-off dates', () => {
+        expect(isDateInCurrentWeek('')).toBe(false);
+        expect(isDateInCurrentWeek('1999-01-01')).toBe(false);
+    });
+});
+
+


### PR DESCRIPTION
## Summary
Adds **Exam Mode**: a compact serpentine "exam roadmap" that replaces the right column (Weekly Schedule + Homework) during the exam period. It activates automatically when today falls within (firstExam - 14 days) .. lastExam, with a subtle per-semester manual override (Schedule / Exams / Auto).

## What is included
- New `js/exam-mode.js` (pure logic, serpentine rendering, delegated events, custom-exam modal) and `css/exam-mode.css` (theme-aware, responsive, reduced-motion).
- Nodes from each course Moed A/B exam plus user-defined custom exams, sorted by date; passed / today / next states, next-exam countdown, progress, study-gap day chips, Moed A/B filter, and non-destructive hide/restore with an always-visible hidden tray.
- 3-column responsive layout with grid-aligned partial rows; single-column flow on mobile.
- Persists `examViewMode`, `hiddenExamIds`, and `customExams` per semester through the compact v2 schema (localStorage, Firebase sync, export/import).
- Security: all user strings escaped before `innerHTML`, colors sanitized, node actions via `data-*` event delegation.

## Tests
- New `tests/exam-mode.test.js` (pure logic + persistence round-trip); repaired the stale `tests/utils.test.js` to the current API. 140 tests pass via `npx jest`.
- Made jest `testMatch` path-robust and disabled `http-server` cache in the `serve` script.

## Note
`npm test` runs `jest --coverage` and exits non-zero only because the repo eval-based test harness reports 0% instrumented coverage against the pre-existing 50% gate (not introduced by this feature). `npx jest` is fully green.