### PR TITLE
feat(layout): add resizable split panes for desktop

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -4,16 +4,18 @@
  */
 
 .calendar-container {
-    flex: 2;
+    /* Width is controlled by Split.js on desktop (no flex value) */
     background: var(--bg-secondary);
     border-radius: 2px;
     padding: 25px;
     border: 1px solid var(--border-primary);
-    min-width: 350px;
+    min-width: 0; /* Allow the pane to shrink */
+    width: 100%;
     height: 100%;
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    box-sizing: border-box;
 }
 
 /* Calendar scroll wrapper - for horizontal scrolling on mobile */
@@ -22,6 +24,8 @@
     overflow-y: visible;
     margin: 0 -25px;
     padding: 0 25px;
+    width: calc(100% + 50px); /* Account for the negative side margins */
+    box-sizing: border-box;
 }
 
 /* Full width in single day mode */
@@ -36,11 +40,13 @@
 /* Weekly Schedule Grid */
 .weekly-schedule {
     display: grid;
-    grid-template-columns: 40px repeat(6, 1fr); /* Time col + 6 days (Sun-Fri) */
+    grid-template-columns: 40px repeat(6, minmax(0, 1fr)); /* Time col + 6 fluid days (Sun-Fri) */
     gap: 2px;
     background: var(--border-primary);
     border: 1px solid var(--border-primary);
     font-size: 10px;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .schedule-header {

--- a/css/layout.css
+++ b/css/layout.css
@@ -12,9 +12,52 @@
     height: 100%;
 }
 
+/* Split.js parent container (desktop resizable panes) */
+.split-parent {
+    display: flex;
+    flex-direction: row;
+    gap: 0; /* Spacing is provided by the Split.js gutter instead */
+}
+
+/* Split.js gutter (draggable handle) */
+.gutter {
+    background-color: var(--border-secondary, #e1e1e1);
+    background-repeat: no-repeat;
+    background-position: 50%;
+    cursor: col-resize !important;
+    transition: background-color 0.15s;
+    flex-shrink: 0;
+    z-index: 99;
+}
+
+.gutter:hover {
+    background-color: var(--border-primary, #cdcdcd);
+}
+
+.gutter.gutter-horizontal {
+    width: 4px;
+    margin: 0 2px;
+}
+
+/* Split panes - Split.js controls their widths via inline styles */
+.split-parent > #split-0,
+.split-parent > #split-1 {
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 100%;
+}
+
+/* Dark mode gutter styling */
+body.dark-mode .gutter {
+    background-color: var(--border-secondary, #3a3a3a);
+}
+
+body.dark-mode .gutter:hover {
+    background-color: var(--border-primary, #525252);
+}
+
 .container {
-    flex: 3;
-    /* Existing styles override */
+    /* Width is controlled by Split.js on desktop (no flex value) */
     max-width: none;
     width: auto;
     margin: 0;
@@ -143,6 +186,23 @@ body.dark-mode .theme-icon-moon { display: block !important; }
 /* Mobile day view toggle button */
 #mobile-day-toggle {
     display: none;
+}
+
+/* Fallback proportions for the 901-1024px range, where the two-column row
+   layout is shown but Split.js is intentionally disabled (the panes cannot
+   meet their minimum widths to be resized). Restores a balanced 60/40 split
+   instead of letting the calendar pane's width: 100% squash the left panel.
+   Body has overflow: hidden, so window.innerWidth matches the viewport width
+   used here and this never overlaps the desktop Split.js range (>1024px). */
+@media (min-width: 901px) and (max-width: 1024px) {
+    .split-parent > #split-0 {
+        flex: 3 1 0;
+    }
+
+    .split-parent > #split-1 {
+        flex: 2 1 0;
+        width: auto;
+    }
 }
 
 /* ========================================

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
     <link rel="stylesheet" href="css/utils.css">
 </head>
 <body>
-    <div class="app-layout">
-        <div class="container">
+    <div class="app-layout split-parent">
+        <div id="split-0" class="container">
             <header>
                 <div class="brand">
                     <h1>Tollab</h1>
@@ -74,7 +74,7 @@
         </button>
     </div>
 
-    <div class="calendar-container">
+    <div id="split-1" class="calendar-container">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; flex-wrap: wrap; gap: 10px;">
             <h2 style="margin: 0; font-size: 20px; font-weight: 300;">Weekly Schedule</h2>
             <div style="display: flex; align-items: center; gap: 10px;">
@@ -666,5 +666,52 @@
     <script src="js/import-export.js"></script>
     <script src="js/events.js"></script>
     <script src="js/main.js"></script>
+    <!-- Split.js: resizable left/right panes (desktop only) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/split.js/1.6.0/split.min.js"></script>
+    <script>
+        // Initialize resizable split panes on desktop, after all scripts load.
+        (function initSplitPanes() {
+            // Enable only on desktop, where both panes can meet their min widths.
+            var DESKTOP_MIN_WIDTH = 1024;
+            if (window.innerWidth <= DESKTOP_MIN_WIDTH) {
+                return;
+            }
+
+            if (typeof Split === 'undefined') {
+                console.warn('[Split] Split.js failed to load; using default layout.');
+                return;
+            }
+
+            var STORAGE_KEY = 'tollab_split_sizes';
+            var DEFAULT_SIZES = [65, 35];
+
+            var sizes = DEFAULT_SIZES;
+            try {
+                var stored = localStorage.getItem(STORAGE_KEY);
+                if (stored) {
+                    var parsed = JSON.parse(stored);
+                    if (Array.isArray(parsed) && parsed.length === 2) {
+                        sizes = parsed;
+                    }
+                }
+            } catch (e) {
+                console.warn('[Split] Could not read saved sizes:', e);
+            }
+
+            Split(['#split-0', '#split-1'], {
+                sizes: sizes,
+                minSize: [580, 400], // Left pane >= 580px, right pane >= 400px
+                gutterSize: 4,
+                cursor: 'col-resize',
+                onDragEnd: function (newSizes) {
+                    try {
+                        localStorage.setItem(STORAGE_KEY, JSON.stringify(newSizes));
+                    } catch (e) {
+                        console.warn('[Split] Could not save sizes:', e);
+                    }
+                }
+            });
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Re-introduces the resizable split-pane layout (originally on the never-merged `feature/ui-split-pane` branch) on top of current `main`. The left course panel and the right calendar panel can be resized by dragging a gutter between them, and the chosen sizes persist across reloads.

Powered by [Split.js](https://github.com/nathancahill/split) 1.6.0 (version-pinned, from cdnjs).

## Changes

- **index.html**: `app-layout` gains a `split-parent` class; the two panels get `id="split-0"` / `id="split-1"`; Split.js is loaded and initialized in a desktop-only inline script.
- **css/layout.css**: `.split-parent`, `.gutter` (light + dark mode), and pane overflow rules; removed `flex: 3` from `.container`; added a `901-1024px` fallback so the non-split row layout stays balanced.
- **css/calendar.css**: calendar pane made fluid (`min-width: 0; width: 100%; box-sizing`); weekly grid uses `repeat(6, minmax(0, 1fr))`.

## Behavior

- Desktop (`> 1024px`): draggable gutter, default 65/35, min sizes 580px / 400px, sizes saved to `localStorage` under `tollab_split_sizes`.
- 901-1024px: split disabled (panes cannot meet min widths), falls back to a balanced 60/40 row.
- Mobile (`<= 900px`): unchanged, panels stack vertically.

## Hardening

- Skips init gracefully if the CDN fails to load (`typeof Split` check).
- Validates persisted sizes (array of length 2) before use.
- Storage key follows the repo `tollab_` convention.

## Verification

Browser-tested across breakpoints: desktop drag / persist / restore / min-size clamp, the 1024 vs 1025 boundary handoff, mobile stacking, and dark-mode gutter color. No new html-validate errors (204 baseline = 204 after). No JS modules were touched.
