### PR TITLE
fix(import): read VITE_CORS_PROXY from a Secret too; bypass YouTube consent gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,9 +58,10 @@ jobs:
           # Your own CORS proxy for imports (Cheesefork / YouTube / Panopto), so
           # the site doesn't depend on flaky public proxies. Optional: unset →
           # empty → the app falls back to the public proxy chain. Deploy the
-          # worker in workers/cors-proxy/ and set this repo *Variable* to
-          # `https://<worker>.workers.dev/?url={url}`.
-          VITE_CORS_PROXY: ${{ vars.VITE_CORS_PROXY }}
+          # worker in workers/cors-proxy/ and set VITE_CORS_PROXY to
+          # `https://<worker>.workers.dev/?url={url}` — as EITHER a repo Variable
+          # or a Secret (the `||` picks up whichever you used).
+          VITE_CORS_PROXY: ${{ vars.VITE_CORS_PROXY || secrets.VITE_CORS_PROXY }}
 
       - name: Verify deployable artifact
         run: |

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,15 +59,18 @@ function corsDevProxy(): Plugin {
             fail(403, `Dev CORS proxy: host not allowed (${targetUrl.hostname})`)
             return
           }
-          const upstream = await fetch(target, {
-            redirect: 'follow',
-            headers: {
-              'User-Agent':
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
-              Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-              'Accept-Language': 'en-US,en;q=0.9',
-            },
-          })
+          const upstreamHeaders: Record<string, string> = {
+            'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+          }
+          // Skip YouTube's EU/UK consent interstitial (see workers/cors-proxy).
+          const h = targetUrl.hostname.toLowerCase()
+          if (['youtube.com', 'youtu.be'].some((s) => h === s || h.endsWith(`.${s}`))) {
+            upstreamHeaders.Cookie = 'SOCS=CAI; CONSENT=YES+cb.20210328-17-p0.en+FX+678'
+          }
+          const upstream = await fetch(target, { redirect: 'follow', headers: upstreamHeaders })
           const body = Buffer.from(await upstream.arrayBuffer())
           res.statusCode = upstream.status
           res.setHeader('Access-Control-Allow-Origin', '*')

--- a/workers/cors-proxy/README.md
+++ b/workers/cors-proxy/README.md
@@ -45,13 +45,14 @@ Wrangler prints the deployed `*.workers.dev` URL.
 The app reads a build-time variable `VITE_CORS_PROXY`. The `{url}` placeholder is
 replaced with the encoded target.
 
-1. In GitHub: **Settings → Secrets and variables → Actions → Variables → New
-   repository variable**:
+1. In GitHub: **Settings → Secrets and variables → Actions**, then add
+   `VITE_CORS_PROXY` under **either** the **Variables** tab (recommended — it's a
+   public URL, not a secret) **or** the **Secrets** tab (fine too, and consistent
+   with the Firebase config). The deploy workflow reads from both, so whichever
+   you pick works:
 
    - **Name:** `VITE_CORS_PROXY`
    - **Value:** `https://<your-worker>.workers.dev/?url={url}`
-
-   (It's a public URL, so a _Variable_ is fine — it doesn't need to be a Secret.)
 
 2. Re-run the **Deploy to GitHub Pages** workflow (Actions → _Deploy to GitHub
    Pages_ → _Run workflow_). The new build bakes the proxy URL in, and the app

--- a/workers/cors-proxy/worker.js
+++ b/workers/cors-proxy/worker.js
@@ -48,6 +48,11 @@ function hostAllowed(hostname) {
   return ALLOWED_HOST_SUFFIXES.some((suffix) => h === suffix || h.endsWith('.' + suffix))
 }
 
+function isYouTubeHost(hostname) {
+  const h = hostname.toLowerCase()
+  return ['youtube.com', 'youtu.be'].some((s) => h === s || h.endsWith('.' + s))
+}
+
 function corsHeaders(origin) {
   // Open to all when no origins are configured; otherwise echo an allowed
   // caller and fall back to the first configured origin for anyone else (so a
@@ -100,6 +105,21 @@ export default {
       return new Response('Host not allowed: ' + targetUrl.hostname, { status: 403, headers: cors })
     }
 
+    const upstreamHeaders = {
+      // A desktop UA so pages like YouTube return their full ytInitialData.
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9',
+    }
+    // Skip YouTube's EU/UK "before you continue" consent interstitial
+    // (consent.youtube.com/m…), which otherwise 3xx's the fetch away from the
+    // playlist page to a cookie wall. SOCS=CAI satisfies the current consent
+    // flow; CONSENT=YES+ the older /m interstitial. Harmless to non-EU regions.
+    if (isYouTubeHost(targetUrl.hostname)) {
+      upstreamHeaders.Cookie = 'SOCS=CAI; CONSENT=YES+cb.20210328-17-p0.en+FX+678'
+    }
+
     let upstream
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS)
@@ -107,13 +127,7 @@ export default {
       upstream = await fetch(targetUrl.toString(), {
         redirect: 'follow',
         signal: controller.signal,
-        headers: {
-          // A desktop UA so pages like YouTube return their full ytInitialData.
-          'User-Agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
-          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-          'Accept-Language': 'en-US,en;q=0.9',
-        },
+        headers: upstreamHeaders,
       })
     } catch (err) {
       const timedOut = err && err.name === 'AbortError'


### PR DESCRIPTION
Two fixes found while testing the deployed worker on the live site.

## 1. The live site wasn't using the worker (the main fix)

The worker was deployed and `VITE_CORS_PROXY` was set — but as a repository **Secret**, while the deploy workflow only read it as a **Variable** (`${{ vars.VITE_CORS_PROXY }}`). So `vars.` was empty, the build baked in nothing, and the site kept falling back to the public `proxy.cors.sh`.

Fix: read it from **either** place —
```yaml
VITE_CORS_PROXY: ${{ vars.VITE_CORS_PROXY || secrets.VITE_CORS_PROXY }}
```
Robust and future-proof; no matter which tab it's set in, the build picks it up.

## 2. YouTube consent gate broke recording imports

In the EU/UK, YouTube 3xx-redirects the playlist fetch to its "before you continue" consent interstitial (`consent.youtube.com/m…`), which has no CORS header — so the import failed. Fix: send a consent cookie (`SOCS=CAI; CONSENT=YES+…`) for `youtube.com`/`youtu.be` requests in **both** the Cloudflare Worker and the Vite dev proxy, so the playlist page loads directly. Verified the cookie keeps `ytInitialData` and watch links intact (it only affects EU/UK regions; harmless elsewhere). This is a server-side-only fix, so it needs the worker (public proxies can't attach the cookie).

## Verification

Local gates green: typecheck, lint (0 warnings), format, importer tests (186), worker syntax-checked.

## After merge

Re-run **Deploy to GitHub Pages** — the build will then bake in your `VITE_CORS_PROXY` (from the Secret) and the site will use your worker: Cheesefork fast, YouTube working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)