### PR TITLE
fix(import): name the semester from Cheesefork's NAME property

### DIFF
--- a/src/services/importers/__fixtures__/cheesefork.ics
+++ b/src/services/importers/__fixtures__/cheesefork.ics
@@ -3,7 +3,7 @@ VERSION:2.0
 PRODID:-//CheeseFork//cheesefork.cf//EN
 CALSCALE:GREGORIAN
 METHOD:PUBLISH
-X-WR-CALNAME:מערכת שעות - סמסטר אביב 2026
+NAME:אביב 2026
 X-WR-TIMEZONE:Asia/Jerusalem
 BEGIN:VEVENT
 UID:cheesefork-234247-lec-1@cheesefork.cf

--- a/src/services/importers/ics.test.ts
+++ b/src/services/importers/ics.test.ts
@@ -307,6 +307,11 @@ describe('parseIcs — semester hint', () => {
     expect(parseIcs(text).semesterHint).toBe('Summer 2025')
   })
 
+  it('reads the RFC 7986 NAME property (what Cheesefork actually sends)', () => {
+    const text = ics(['NAME:אביב 2026'])
+    expect(parseIcs(text).semesterHint).toBe('Spring 2026')
+  })
+
   it('returns null when a season appears without a year', () => {
     const text = ics(['X-WR-CALNAME:סמסטר אביב'])
     expect(parseIcs(text).semesterHint).toBeNull()

--- a/src/services/importers/ics.ts
+++ b/src/services/importers/ics.ts
@@ -91,7 +91,11 @@ function collectEvents(lines: string[]): { events: IcsEvent[]; calendarName: str
       else if (key === 'LOCATION') current.location = unescapeIcsText(value)
       else if (key === 'DTSTART') current.dtstart = value
       else if (key === 'DTEND') current.dtend = value
-    } else if (key === 'X-WR-CALNAME' && current === null) {
+    } else if ((key === 'X-WR-CALNAME' || key === 'NAME') && current === null && !calendarName) {
+      // Cheesefork names the calendar with the RFC 7986 `NAME` property, not the
+      // older `X-WR-CALNAME`; accept either (first non-empty wins) so the imported
+      // semester is named from the file (e.g. "Spring 2026") rather than falling
+      // back to a generic "Imported Semester".
       calendarName = unescapeIcsText(value)
     }
   }


### PR DESCRIPTION
Cheesefork exports the calendar name via the RFC 7986 **`NAME`** property (e.g. `NAME:אביב 2026`), but the ICS parser only read the older **`X-WR-CALNAME`**. So a single-schedule import found no calendar name, couldn't derive a hint, and fell back to the generic **"Imported Semester"** instead of **"Spring 2026"**.

Fix: read either property (first non-empty wins). Also updates the test fixture to use `NAME` like real Cheesefork — the old fixture used `X-WR-CALNAME`, which is exactly why this slipped through.

Addresses the **semester-naming** part of #138. (The other two points in that issue — hidden courses excluded from the export, and intermittent connection resets — are a Cheesefork-side export limitation and transient-network behaviour respectively; see the issue reply.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)